### PR TITLE
Avoid double-counting duplicate Codex usage snapshots

### DIFF
--- a/src/__tests__/server/codexParser.test.ts
+++ b/src/__tests__/server/codexParser.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, it, expect, afterEach } from 'vitest';
+import { parseCodexSession } from '../../server/codexParser.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeSession(lines: unknown[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'tokendash-codex-parser-'));
+  tempDirs.push(dir);
+  const filepath = join(dir, 'session.jsonl');
+  writeFileSync(filepath, lines.map(line => JSON.stringify(line)).join('\n'));
+  return filepath;
+}
+
+function tokenCount(timestamp: string, totalTokens: number, outputTokens = 100): unknown {
+  const inputTokens = totalTokens - outputTokens;
+  return {
+    timestamp,
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info: {
+        total_token_usage: {
+          input_tokens: inputTokens,
+          cached_input_tokens: 0,
+          output_tokens: outputTokens,
+          reasoning_output_tokens: 0,
+          total_tokens: totalTokens,
+        },
+        last_token_usage: {
+          input_tokens: inputTokens,
+          cached_input_tokens: 0,
+          output_tokens: outputTokens,
+          reasoning_output_tokens: 0,
+          total_tokens: totalTokens,
+        },
+      },
+    },
+  };
+}
+
+describe('parseCodexSession', () => {
+  it('deduplicates repeated token_count snapshots within a Codex session', () => {
+    const filepath = writeSession([
+      {
+        type: 'session_meta',
+        payload: {
+          id: 'session-1',
+          cwd: '/tmp/project',
+          timestamp: '2026-05-18T00:00:00.000Z',
+        },
+      },
+      tokenCount('2026-05-18T00:00:01.000Z', 1500),
+      tokenCount('2026-05-18T00:00:02.000Z', 1500),
+      tokenCount('2026-05-18T00:00:03.000Z', 2100),
+    ]);
+
+    const session = parseCodexSession(filepath);
+
+    expect(session?.tokenEvents).toHaveLength(2);
+    expect(session?.tokenEvents.map(ev => ev.totalTokens)).toEqual([1500, 2100]);
+  });
+});

--- a/src/server/codexParser.ts
+++ b/src/server/codexParser.ts
@@ -64,6 +64,16 @@ interface TokenAccumulator {
   totalTokens: number;
 }
 
+function tokenUsageKey(usage: z.infer<typeof TokenUsageSchema>): string {
+  return [
+    usage.input_tokens,
+    usage.cached_input_tokens,
+    usage.output_tokens,
+    usage.reasoning_output_tokens,
+    usage.total_tokens,
+  ].join(':');
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -118,11 +128,10 @@ export function scanCodexSessions(): string[] {
 /**
  * Parse a single Codex session JSONL file.
  *
- * CRITICAL INVARIANT: Sum ALL token_count events without any deduplication.
- * Each Codex turn emits TWO token_count events with identical last_token_usage
- * values (~1-2s apart) — one for reasoning, one for output completion.
- * Both are distinct billable events. Deduplicating would produce the wrong
- * total (4.7M instead of the correct 9.2M).
+ * Codex can emit duplicate token_count events for the same turn, with identical
+ * total_token_usage and last_token_usage snapshots a few seconds apart. These
+ * are repeated status updates, not separate billable usage records, so only the
+ * first occurrence of each cumulative total_token_usage snapshot should count.
  */
 export function parseCodexSession(filepath: string): ParsedSession | null {
   let content: string;
@@ -138,6 +147,7 @@ export function parseCodexSession(filepath: string): ParsedSession | null {
   let model = '';
   let createdAt = '';
   const tokenEvents: ParsedTokenEvent[] = [];
+  const seenTotalUsageSnapshots = new Set<string>();
 
   for (const line of lines) {
     const trimmed = line.trim();
@@ -167,7 +177,6 @@ export function parseCodexSession(filepath: string): ParsedSession | null {
     }
 
     // Extract token counts from event_msg with nested token_count payload.
-    // NEVER deduplicate — see invariant comment above.
     if (type === 'event_msg') {
       const payload = (obj.payload as Record<string, unknown>) || {};
       if (payload.type === 'token_count') {
@@ -179,6 +188,10 @@ export function parseCodexSession(filepath: string): ParsedSession | null {
         }
         const info = parseResult.data.info;
         if (!info) continue;
+        const totalUsageKey = tokenUsageKey(info.total_token_usage);
+        if (seenTotalUsageSnapshots.has(totalUsageKey)) continue;
+        seenTotalUsageSnapshots.add(totalUsageKey);
+
         const last = info.last_token_usage;
         tokenEvents.push({
           timestamp,


### PR DESCRIPTION
## Summary
- Deduplicate repeated Codex `token_count` snapshots within a session before aggregation.
- Replace the old "sum every token_count event" invariant with the observed Codex behavior: duplicate status updates can carry identical `total_token_usage` and `last_token_usage` snapshots a few seconds apart.
- Add a regression test covering duplicate snapshot handling.

## Why
On local Codex logs, daily totals were roughly doubled because repeated `token_count` events with the same cumulative `total_token_usage` snapshot were counted as separate usage records. Since `cached_input_tokens` is already included in `input_tokens`, and `reasoning_output_tokens` is already included in `output_tokens`, the reliable total remains `total_tokens = input_tokens + output_tokens`; duplicated snapshots should not be added again.

## Verification
- `npm test -- src/__tests__/server/codexParser.test.ts`
- `npm run build`

## Notes
- Full `npm test` currently fails on an unrelated existing test: `src/__tests__/server/electron.test.ts > createApp > serves /popover.html`, where `/popover.html` returns 404 instead of 200.
