### PR TITLE
Fix CLI production asset path

### DIFF
--- a/src/__tests__/server/electron.test.ts
+++ b/src/__tests__/server/electron.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { createApp } from '../../server/index.js';
+import { createApp, resolveStaticAssetBaseDir } from '../../server/index.js';
 import http from 'node:http';
 import { createRequire } from 'node:module';
+import { join } from 'node:path';
 
 const require = createRequire(import.meta.url);
 const { formatCost, formatTokens } = require('../../../electron/trayBadge.cjs') as {
@@ -31,8 +32,8 @@ describe('createApp', () => {
     }
   });
 
-  it('serves /popover.html', async () => {
-    const app = createApp(0);
+  it('serves /popover.html when the static file is present', async () => {
+    const app = createApp(0, join(process.cwd(), 'dist'));
     const server = app.listen(0);
     const address = server.address();
     if (!address || typeof address === 'string') throw new Error('no address');
@@ -48,6 +49,30 @@ describe('createApp', () => {
     } finally {
       server.close();
     }
+  });
+});
+
+
+describe('resolveStaticAssetBaseDir', () => {
+  it('resolves CLI production assets from dist/server to dist', () => {
+    const resolved = resolveStaticAssetBaseDir('file:///opt/homebrew/lib/node_modules/@zhangferry-dev/tokendash/dist/server/index.js');
+
+    expect(resolved).toEqual({
+      baseDir: '/opt/homebrew/lib/node_modules/@zhangferry-dev/tokendash/dist',
+      isProduction: true,
+    });
+  });
+
+  it('keeps explicit production base directories unchanged', () => {
+    const resolved = resolveStaticAssetBaseDir('file:///app/dist/server/index.js', '/app/dist');
+
+    expect(resolved).toEqual({ baseDir: '/app/dist', isProduction: true });
+  });
+
+  it('keeps source server directories in development', () => {
+    const resolved = resolveStaticAssetBaseDir('file:///repo/src/server/index.ts');
+
+    expect(resolved).toEqual({ baseDir: '/repo/src/server', isProduction: false });
   });
 });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,9 +1,9 @@
 import express from 'express';
 import type { Express } from 'express';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import type { Server } from 'node:http';
 import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { registerApiRoutes } from './routes/api.js';
 import { detectAvailableAgents } from './agentDetection.js';
 import open from 'open';
@@ -141,6 +141,25 @@ async function listenWithPortFallback(app: Express, preferredPort: number): Prom
   throw new Error(`Could not find an available port starting from ${preferredPort}`);
 }
 
+export function resolveStaticAssetBaseDir(moduleUrl = import.meta.url, baseDir?: string): { baseDir: string; isProduction: boolean } {
+  if (baseDir) return { baseDir: resolve(baseDir), isProduction: true };
+
+  const moduleDir = dirname(fileURLToPath(moduleUrl));
+  const isProduction = moduleUrl.includes('/dist/');
+
+  if (!isProduction) return { baseDir: resolve(moduleDir), isProduction: false };
+
+  // The CLI entrypoint runs from dist/server/index.js while the Vite assets are
+  // emitted to dist/client. Resolve the production asset base to dist instead
+  // of dist/server so / resolves to dist/client/index.html in installed npm
+  // packages. Electron passes dist explicitly and is unaffected by this branch.
+  if (basename(moduleDir) === 'server') {
+    return { baseDir: resolve(dirname(moduleDir)), isProduction: true };
+  }
+
+  return { baseDir: resolve(moduleDir), isProduction: true };
+}
+
 export function createApp(_port: number, baseDir?: string): Express {
   const app = express();
   const router = express.Router();
@@ -149,17 +168,17 @@ export function createApp(_port: number, baseDir?: string): Express {
   registerApiRoutes(router);
   app.use('/api', router);
 
-  // Resolve paths: use provided baseDir or compute from import.meta.url
-  const _baseDir = baseDir ?? dirname(fileURLToPath(import.meta.url));
-  const isProduction = baseDir
-    ? true
-    : import.meta.url.includes('dist/');
+  const { baseDir: _baseDir, isProduction } = resolveStaticAssetBaseDir(import.meta.url, baseDir);
   const popoverPath = isProduction
     ? join(_baseDir, 'client', 'popover.html')
     : join(_baseDir, '..', '..', 'public', 'popover.html');
 
-  app.get('/popover.html', (_req, res) => {
-    res.sendFile(popoverPath);
+  app.get('/popover.html', (_req, res, next) => {
+    if (!existsSync(popoverPath)) {
+      next();
+      return;
+    }
+    res.type('html').send(readFileSync(popoverPath, 'utf8'));
   });
 
   // Check if running from dist (production build)


### PR DESCRIPTION
## Summary
- resolve production static assets from the package `dist` root when the CLI runs from `dist/server/index.js`
- keep Electron's explicit asset base behavior unchanged
- add regression coverage for CLI production asset resolution

## Verification
- `npm run build`
- `npm test`
- `node bin/tokendash.js --port 45678 --no-open` then verified `/`, `/popover.html`, and `/api/agents` return 200

## Notes
This fixes the installed CLI error where Express looked for `dist/server/client/index.html` instead of `dist/client/index.html`.