### PR TITLE
Keep dashboard usage data consistent

### DIFF
--- a/src/__tests__/client/cacheCalculations.test.ts
+++ b/src/__tests__/client/cacheCalculations.test.ts
@@ -6,9 +6,13 @@ describe('cacheHitRate', () => {
     expect(cacheHitRate(1000, 0)).toBe(0);
   });
 
-  it('calculates hit rate as percentage', () => {
-    // cacheHitRate(cacheReadTokens, inputTokens) = cacheRead / input * 100
+  it('calculates hit rate against all input tokens', () => {
+    // cached input is already part of input_tokens, so do not add it again.
     expect(cacheHitRate(500, 1000)).toBe(50);
+  });
+
+  it('does not dilute the hit rate by adding cached input to input again', () => {
+    expect(cacheHitRate(500, 1000)).not.toBeCloseTo((500 / 1500) * 100, 5);
   });
 
   it('returns 0 when both are 0', () => {

--- a/src/__tests__/server/codexParser.test.ts
+++ b/src/__tests__/server/codexParser.test.ts
@@ -2,7 +2,8 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, it, expect, afterEach } from 'vitest';
-import { parseCodexSession } from '../../server/codexParser.js';
+import { buildCodexResponsesFromSessions, parseCodexSession, type ParsedSession } from '../../server/codexParser.js';
+import type { DailyEntry, Totals } from '../../shared/types.js';
 
 const tempDirs: string[] = [];
 
@@ -48,6 +49,43 @@ function tokenCount(timestamp: string, totalTokens: number, outputTokens = 100):
   };
 }
 
+function session(id: string, cwd: string, model: string, tokenEvents: ParsedSession['tokenEvents']): ParsedSession {
+  return {
+    id,
+    cwd,
+    model,
+    createdAt: tokenEvents[0]?.timestamp ?? '2026-05-18T00:00:00.000Z',
+    tokenEvents,
+  };
+}
+
+function event(
+  timestamp: string,
+  inputTokens: number,
+  outputTokens: number,
+  cachedInputTokens = 0,
+): ParsedSession['tokenEvents'][number] {
+  return {
+    timestamp,
+    inputTokens,
+    cachedInputTokens,
+    outputTokens,
+    reasoningOutputTokens: 0,
+    totalTokens: inputTokens + outputTokens,
+  };
+}
+
+function sumDaily(entries: DailyEntry[]): Totals {
+  return entries.reduce((acc, entry) => ({
+    inputTokens: acc.inputTokens + entry.inputTokens,
+    outputTokens: acc.outputTokens + entry.outputTokens,
+    cacheCreationTokens: acc.cacheCreationTokens + entry.cacheCreationTokens,
+    cacheReadTokens: acc.cacheReadTokens + entry.cacheReadTokens,
+    totalTokens: acc.totalTokens + entry.totalTokens,
+    totalCost: acc.totalCost + entry.totalCost,
+  }), { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 0, totalCost: 0 });
+}
+
 describe('parseCodexSession', () => {
   it('deduplicates repeated token_count snapshots within a Codex session', () => {
     const filepath = writeSession([
@@ -68,5 +106,85 @@ describe('parseCodexSession', () => {
 
     expect(session?.tokenEvents).toHaveLength(2);
     expect(session?.tokenEvents.map(ev => ev.totalTokens)).toEqual([1500, 2100]);
+  });
+});
+
+describe('buildCodexResponsesFromSessions', () => {
+  it('keeps daily, project table, and block totals consistent', () => {
+    const responses = buildCodexResponsesFromSessions([
+      session('s1', '/repo/project-a', 'gpt-5.4', [
+        event('2026-05-18T01:00:00.000Z', 1_000, 50, 400),
+        event('2026-05-18T03:00:00.000Z', 2_000, 100, 500),
+      ]),
+      session('s2', '/repo/project-a', 'gpt-5.5', [
+        event('2026-05-18T04:00:00.000Z', 3_000, 150, 600),
+      ]),
+      session('s3', '/repo/project-b', 'gpt-5.4', [
+        event('2026-05-19T01:00:00.000Z', 4_000, 200, 700),
+      ]),
+    ], { timezone: 'UTC' });
+
+    const projectEntries = Object.values(responses.projects.projects).flat();
+    const projectTotals = sumDaily(projectEntries);
+    const blockTotals = responses.blocks.blocks.reduce((acc, block) => ({
+      inputTokens: acc.inputTokens + block.tokenCounts.inputTokens,
+      outputTokens: acc.outputTokens + block.tokenCounts.outputTokens,
+      cacheCreationTokens: acc.cacheCreationTokens + block.tokenCounts.cacheCreationInputTokens,
+      cacheReadTokens: acc.cacheReadTokens + block.tokenCounts.cacheReadInputTokens,
+      totalTokens: acc.totalTokens + block.totalTokens,
+      totalCost: acc.totalCost + block.costUSD,
+    }), { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 0, totalCost: 0 });
+
+    expect(projectTotals).toMatchObject({
+      inputTokens: responses.daily.totals.inputTokens,
+      outputTokens: responses.daily.totals.outputTokens,
+      cacheCreationTokens: responses.daily.totals.cacheCreationTokens,
+      cacheReadTokens: responses.daily.totals.cacheReadTokens,
+      totalTokens: responses.daily.totals.totalTokens,
+    });
+    expect(projectTotals.totalCost).toBeCloseTo(responses.daily.totals.totalCost, 12);
+    expect(blockTotals).toMatchObject({
+      inputTokens: responses.daily.totals.inputTokens,
+      outputTokens: responses.daily.totals.outputTokens,
+      cacheCreationTokens: responses.daily.totals.cacheCreationTokens,
+      cacheReadTokens: responses.daily.totals.cacheReadTokens,
+      totalTokens: responses.daily.totals.totalTokens,
+    });
+    expect(blockTotals.totalCost).toBeCloseTo(responses.daily.totals.totalCost, 12);
+  });
+
+  it('merges multiple same-day sessions into one project table row', () => {
+    const responses = buildCodexResponsesFromSessions([
+      session('s1', '/repo/project-a', 'gpt-5.4', [event('2026-05-18T01:00:00.000Z', 1_000, 50)]),
+      session('s2', '/repo/project-a', 'gpt-5.5', [event('2026-05-18T02:00:00.000Z', 2_000, 100)]),
+    ], { timezone: 'UTC' });
+
+    const entries = responses.projects.projects['project-a'];
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      date: '2026-05-18',
+      inputTokens: 3_000,
+      outputTokens: 150,
+      totalTokens: 3_150,
+    });
+    expect(entries[0].modelsUsed.sort()).toEqual(['gpt-5.4', 'gpt-5.5']);
+  });
+
+  it('does not count cache reads again in Codex model totals', () => {
+    const responses = buildCodexResponsesFromSessions([
+      session('s1', '/repo/project-a', 'gpt-5.4', [event('2026-05-18T01:00:00.000Z', 1_000, 50, 900)]),
+    ], { timezone: 'UTC' });
+
+    const daily = responses.daily.daily[0];
+    const modelTokens = daily.modelBreakdowns.reduce((sum, model) => sum + model.inputTokens + model.outputTokens, 0);
+    const modelTokensWithCacheDoubleCounted = daily.modelBreakdowns.reduce(
+      (sum, model) => sum + model.inputTokens + model.outputTokens + model.cacheReadTokens,
+      0,
+    );
+
+    expect(daily.totalTokens).toBe(1_050);
+    expect(modelTokens).toBe(daily.totalTokens);
+    expect(modelTokensWithCacheDoubleCounted).toBe(1_950);
   });
 });

--- a/src/client/components/Dashboard.tsx
+++ b/src/client/components/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
+import type { ReactElement } from 'react';
 import {
   BarChart, Bar, Cell, LineChart, Line,
   ComposedChart, AreaChart, Area, PieChart, Pie,
@@ -9,7 +10,7 @@ import type { AgentsResponse } from '../api/client.js';
 import { useCcusageData } from '../hooks/useCcusageData.js';
 import { useLocalStorageState } from '../hooks/useLocalStorageState.js';
 import { formatDate, formatTokens, formatUSD, formatPercent, formatProjectName } from '../utils/formatters.js';
-import { costSavedByCache } from '../utils/cacheCalculations.js';
+import { cacheHitRate as calculateCacheHitRate, costSavedByCache } from '../utils/cacheCalculations.js';
 
 import { shortModelName } from '../utils/modelNames.js';
 import { AnalyticsSection } from './AnalyticsSection.js';
@@ -179,6 +180,18 @@ function filterProjectDaily(projects: Record<string, DailyEntry[]>, project: str
   return filterByTime(projects[project] || [], range);
 }
 
+
+function modelTokenMode(entry: DailyEntry): 'inputOutput' | 'withCache' {
+  const inputOutput = entry.modelBreakdowns.reduce((sum, b) => sum + b.inputTokens + b.outputTokens, 0);
+  const withCache = entry.modelBreakdowns.reduce((sum, b) => sum + b.inputTokens + b.outputTokens + b.cacheReadTokens, 0);
+  return Math.abs(entry.totalTokens - inputOutput) <= Math.abs(entry.totalTokens - withCache) ? 'inputOutput' : 'withCache';
+}
+
+function modelBreakdownTokens(breakdown: DailyEntry['modelBreakdowns'][number], mode: 'inputOutput' | 'withCache'): number {
+  const base = breakdown.inputTokens + breakdown.outputTokens;
+  return mode === 'withCache' ? base + breakdown.cacheReadTokens : base;
+}
+
 /* ---- Main Dashboard ---- */
 
 export function Dashboard() {
@@ -306,7 +319,7 @@ export function Dashboard() {
         hour: `${h.padStart(2, '0')}:00`,
         cacheRead: d.cacheRead,
         input: d.input,
-        hitRate: d.input > 0 ? (d.cacheRead / (d.cacheRead + d.input)) * 100 : 0,
+        hitRate: calculateCacheHitRate(d.cacheRead, d.input),
       }));
   }, [isToday, blocksData.data]);
 
@@ -345,7 +358,7 @@ export function Dashboard() {
     const totalLines = trend.reduce((s, d) => s + d.linesAdded + d.linesDeleted, 0);
     return Math.round(totalLines / trend.length);
   }, [analyticsData.data]);
-  const cacheHitRate = totals.inputTokens > 0 ? (totals.cacheReadTokens / (totals.cacheReadTokens + totals.inputTokens)) * 100 : 0;
+  const cacheHitRate = calculateCacheHitRate(totals.cacheReadTokens, totals.inputTokens);
   const outputRatio = totals.inputTokens > 0 ? (totals.outputTokens / totals.inputTokens) * 100 : 0;
 
   // Cache Savings Data
@@ -361,10 +374,11 @@ export function Dashboard() {
   const modelAgg = useMemo(() => {
     const map: Record<string, { tokens: number; cost: number; input: number; output: number; cacheRead: number }> = {};
     for (const d of filteredDaily) {
+      const tokenMode = modelTokenMode(d);
       for (const b of d.modelBreakdowns) {
         const name = shortModelName(b.modelName);
         if (!map[name]) map[name] = { tokens: 0, cost: 0, input: 0, output: 0, cacheRead: 0 };
-        map[name].tokens += b.inputTokens + b.outputTokens + b.cacheReadTokens;
+        map[name].tokens += modelBreakdownTokens(b, tokenMode);
         map[name].cost += b.cost;
         map[name].input += b.inputTokens;
         map[name].output += b.outputTokens;
@@ -378,9 +392,10 @@ export function Dashboard() {
   const modelTrendData = useMemo(() => {
     return filteredDaily.map(d => {
       const entry: Record<string, string | number> = { date: formatDate(d.date) };
+      const tokenMode = modelTokenMode(d);
       for (const b of d.modelBreakdowns) {
         const name = shortModelName(b.modelName);
-        entry[name] = (entry[name] as number || 0) + (isTokens ? b.inputTokens + b.outputTokens + b.cacheReadTokens : b.cost);
+        entry[name] = (entry[name] as number || 0) + (isTokens ? modelBreakdownTokens(b, tokenMode) : b.cost);
       }
       return entry;
     });
@@ -408,7 +423,7 @@ export function Dashboard() {
     date: formatDate(d.date),
     cacheRead: d.cacheReadTokens,
     input: d.inputTokens,
-    hitRate: d.inputTokens > 0 ? (d.cacheReadTokens / (d.cacheReadTokens + d.inputTokens)) * 100 : 0,
+    hitRate: calculateCacheHitRate(d.cacheReadTokens, d.inputTokens),
   })), [filteredDaily]);
 
   // Output/Input trend data (for single project view)
@@ -461,7 +476,7 @@ export function Dashboard() {
   }, [blocksData.data, timeRange, isTokens]);
 
 
-  const AGENT_CONFIG: Record<string, { label: string; activeColor: string; icon: JSX.Element }> = {
+  const AGENT_CONFIG: Record<string, { label: string; activeColor: string; icon: ReactElement }> = {
     claude: {
       label: 'Claude Code',
       activeColor: 'text-indigo-600',

--- a/src/server/codexParser.ts
+++ b/src/server/codexParser.ts
@@ -2,7 +2,7 @@ import { readFileSync, readdirSync, statSync, accessSync, constants } from 'node
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { z } from 'zod';
-import type { DailyEntry, DailyResponse, ProjectsResponse, BlockEntry, BlocksResponse, Totals, ModelBreakdown } from '../shared/types.js';
+import type { DailyEntry, DailyResponse, ProjectsResponse, BlockEntry, BlocksResponse, ModelBreakdown } from '../shared/types.js';
 import { calculateCost } from './codexPricing.js';
 
 // ---------------------------------------------------------------------------
@@ -31,7 +31,7 @@ const TokenCountPayloadSchema = z.object({
 // Types
 // ---------------------------------------------------------------------------
 
-interface ParsedTokenEvent {
+export interface ParsedTokenEvent {
   timestamp: string;
   inputTokens: number;
   cachedInputTokens: number;
@@ -62,6 +62,11 @@ interface TokenAccumulator {
   outputTokens: number;
   reasoningOutputTokens: number;
   totalTokens: number;
+}
+
+interface AggregateBucket {
+  acc: TokenAccumulator;
+  models: Map<string, TokenAccumulator>;
 }
 
 function tokenUsageKey(usage: z.infer<typeof TokenUsageSchema>): string {
@@ -282,8 +287,17 @@ function mergeAcc(a: TokenAccumulator, b: TokenAccumulator): void {
   a.totalTokens += b.totalTokens;
 }
 
-function accToEntry(date: string, acc: TokenAccumulator, models: Set<string>): DailyEntry {
-  const cost = calculateCost(acc, models);
+function addAccToBucket(bucket: AggregateBucket, ev: ParsedTokenEvent, model: string): void {
+  addAcc(bucket.acc, ev);
+  if (!model) return;
+  if (!bucket.models.has(model)) bucket.models.set(model, emptyAcc());
+  addAcc(bucket.models.get(model)!, ev);
+}
+
+function accToEntry(date: string, acc: TokenAccumulator, modelAccs: Map<string, TokenAccumulator>): DailyEntry {
+  const modelNames = [...modelAccs.keys()];
+  const modelBreakdowns = buildModelBreakdowns(modelAccs);
+  const totalCost = modelBreakdowns.reduce((sum, model) => sum + model.cost, 0);
   return {
     date,
     inputTokens: acc.inputTokens,
@@ -291,23 +305,20 @@ function accToEntry(date: string, acc: TokenAccumulator, models: Set<string>): D
     cacheCreationTokens: 0,
     cacheReadTokens: acc.cachedInputTokens,
     totalTokens: acc.totalTokens,
-    totalCost: cost,
-    modelsUsed: [...models],
-    modelBreakdowns: buildModelBreakdowns(acc, models, cost),
+    totalCost,
+    modelsUsed: modelNames,
+    modelBreakdowns,
   };
 }
 
-function buildModelBreakdowns(acc: TokenAccumulator, models: Set<string>, totalCost: number): ModelBreakdown[] {
-  const modelList = [...models];
-  if (modelList.length === 0) return [];
-  const costPerModel = totalCost / modelList.length;
-  return modelList.map(name => ({
-    modelName: name,
+function buildModelBreakdowns(modelAccs: Map<string, TokenAccumulator>): ModelBreakdown[] {
+  return [...modelAccs.entries()].map(([modelName, acc]) => ({
+    modelName,
     inputTokens: acc.inputTokens,
     outputTokens: acc.outputTokens,
     cacheCreationTokens: 0,
     cacheReadTokens: acc.cachedInputTokens,
-    cost: costPerModel,
+    cost: calculateCost(acc, new Set([modelName])),
   }));
 }
 
@@ -316,9 +327,9 @@ type GroupKey = string;
 function groupSessions(
   sessions: ParsedSession[],
   options: AggregateOptions,
-): Map<GroupKey, { acc: TokenAccumulator; models: Set<string> }> {
+): Map<GroupKey, AggregateBucket> {
   const tz = options.timezone || 'Asia/Shanghai';
-  const grouped = new Map<GroupKey, { acc: TokenAccumulator; models: Set<string> }>();
+  const grouped = new Map<GroupKey, AggregateBucket>();
 
   for (const session of sessions) {
     if (options.project && extractProjectName(session.cwd) !== options.project) continue;
@@ -338,11 +349,9 @@ function groupSessions(
       }
 
       if (!grouped.has(key)) {
-        grouped.set(key, { acc: emptyAcc(), models: new Set() });
+        grouped.set(key, { acc: emptyAcc(), models: new Map() });
       }
-      const entry = grouped.get(key)!;
-      addAcc(entry.acc, ev);
-      if (session.model) entry.models.add(session.model);
+      addAccToBucket(grouped.get(key)!, ev, session.model);
     }
   }
 
@@ -353,25 +362,36 @@ function groupSessions(
 // Public API — response builders for route handlers
 // ---------------------------------------------------------------------------
 
-/** Aggregate and return DailyResponse format (for /daily?agent=codex) */
-export function getDailyResponse(options?: Partial<AggregateOptions>): DailyResponse {
-  const sessions = parseAllSessions();
+export function buildCodexResponsesFromSessions(
+  sessions: ParsedSession[],
+  options?: Partial<AggregateOptions>,
+): { daily: DailyResponse; projects: ProjectsResponse; blocks: BlocksResponse } {
+  return {
+    daily: buildDailyResponse(sessions, options),
+    projects: buildProjectsResponse(sessions, options),
+    blocks: buildBlocksResponse(sessions, options),
+  };
+}
+
+function buildDailyResponse(sessions: ParsedSession[], options?: Partial<AggregateOptions>): DailyResponse {
   const grouped = groupSessions(sessions, { groupBy: 'day', ...options });
 
   const daily: DailyEntry[] = [];
   const totalsAcc = emptyAcc();
 
+  const totalModels = new Map<string, TokenAccumulator>();
   for (const [date, { acc, models }] of grouped) {
     daily.push(accToEntry(date, acc, models));
     mergeAcc(totalsAcc, acc);
+    for (const [model, modelAcc] of models) {
+      if (!totalModels.has(model)) totalModels.set(model, emptyAcc());
+      mergeAcc(totalModels.get(model)!, modelAcc);
+    }
   }
 
-  // Sort by date ascending
   daily.sort((a, b) => a.date.localeCompare(b.date));
 
-  const models = new Set<string>();
-  for (const s of sessions) if (s.model) models.add(s.model);
-  const totalCost = calculateCost(totalsAcc, models);
+  const totalCost = buildModelBreakdowns(totalModels).reduce((sum, model) => sum + model.cost, 0);
 
   return {
     daily,
@@ -386,17 +406,16 @@ export function getDailyResponse(options?: Partial<AggregateOptions>): DailyResp
   };
 }
 
-/** Aggregate and return ProjectsResponse format (for /projects?agent=codex) */
-export function getProjectsResponse(options?: Partial<AggregateOptions>): ProjectsResponse {
-  const sessions = parseAllSessions();
+function buildProjectsResponse(sessions: ParsedSession[], options?: Partial<AggregateOptions>): ProjectsResponse {
   const tz = options?.timezone || 'Asia/Shanghai';
-  const projects: Record<string, DailyEntry[]> = {};
+  const projectGroups = new Map<string, Map<string, AggregateBucket>>();
 
   for (const session of sessions) {
     const projectName = extractProjectName(session.cwd);
+    if (options?.project && projectName !== options.project) continue;
+    if (!projectGroups.has(projectName)) projectGroups.set(projectName, new Map());
+    const dailyMap = projectGroups.get(projectName)!;
 
-    // Per-project daily grouping
-    const dailyMap = new Map<string, { acc: TokenAccumulator; models: Set<string> }>();
     for (const ev of session.tokenEvents) {
       const evDate = new Date(ev.timestamp);
       if (options?.since && evDate < options.since) continue;
@@ -404,36 +423,30 @@ export function getProjectsResponse(options?: Partial<AggregateOptions>): Projec
 
       const dayKey = getDateKey(ev.timestamp, tz);
       if (!dailyMap.has(dayKey)) {
-        dailyMap.set(dayKey, { acc: emptyAcc(), models: new Set() });
+        dailyMap.set(dayKey, { acc: emptyAcc(), models: new Map() });
       }
-      addAcc(dailyMap.get(dayKey)!.acc, ev);
-      if (session.model) dailyMap.get(dayKey)!.models.add(session.model);
-    }
-
-    if (!projects[projectName]) projects[projectName] = [];
-    for (const [date, { acc, models }] of dailyMap) {
-      projects[projectName].push(accToEntry(date, acc, models));
+      addAccToBucket(dailyMap.get(dayKey)!, ev, session.model);
     }
   }
 
-  // Sort each project's daily entries
-  for (const key of Object.keys(projects)) {
-    projects[key].sort((a, b) => a.date.localeCompare(b.date));
+  const projects: Record<string, DailyEntry[]> = {};
+  for (const [projectName, dailyMap] of projectGroups) {
+    projects[projectName] = [...dailyMap.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, { acc, models }]) => accToEntry(date, acc, models));
   }
 
   return { projects };
 }
 
-/** Aggregate and return BlocksResponse format (hourly, for /blocks?agent=codex) */
-export function getBlocksResponse(options?: Partial<AggregateOptions>): BlocksResponse {
-  const sessions = parseAllSessions();
+function buildBlocksResponse(sessions: ParsedSession[], options?: Partial<AggregateOptions>): BlocksResponse {
   const grouped = groupSessions(sessions, { groupBy: 'hour', ...options });
 
   const blocks: BlockEntry[] = [];
   let idx = 0;
 
   for (const [hourKey, { acc, models }] of grouped) {
-    const cost = calculateCost(acc, models);
+    const cost = buildModelBreakdowns(models).reduce((sum, model) => sum + model.cost, 0);
     const [datePart, timePart] = hourKey.split(' ');
     const hour = timePart.split(':')[0];
 
@@ -453,13 +466,27 @@ export function getBlocksResponse(options?: Partial<AggregateOptions>): BlocksRe
       },
       totalTokens: acc.totalTokens,
       costUSD: cost,
-      models: [...models],
+      models: [...models.keys()],
     });
     idx++;
   }
 
-  // Sort by startTime
   blocks.sort((a, b) => a.startTime.localeCompare(b.startTime));
 
   return { blocks };
+}
+
+/** Aggregate and return DailyResponse format (for /daily?agent=codex) */
+export function getDailyResponse(options?: Partial<AggregateOptions>): DailyResponse {
+  return buildDailyResponse(parseAllSessions(), options);
+}
+
+/** Aggregate and return ProjectsResponse format (for /projects?agent=codex) */
+export function getProjectsResponse(options?: Partial<AggregateOptions>): ProjectsResponse {
+  return buildProjectsResponse(parseAllSessions(), options);
+}
+
+/** Aggregate and return BlocksResponse format (hourly, for /blocks?agent=codex) */
+export function getBlocksResponse(options?: Partial<AggregateOptions>): BlocksResponse {
+  return buildBlocksResponse(parseAllSessions(), options);
 }


### PR DESCRIPTION
## Summary
- aggregate Codex projects by project/day across sessions so dashboard table and project distribution match daily totals
- preserve per-model token/cost buckets for Codex daily, project, and block responses
- align dashboard model chart token values with each entry's total-token semantics and reuse the shared cache hit-rate helper
- add regression tests for Codex daily/project/block consistency, same-day project merging, and avoiding cache read double counting

## Verification
- npm run typecheck
- npx vitest run src/__tests__/server/codexParser.test.ts src/__tests__/client/cacheCalculations.test.ts
- npm run build

## Note
- Full npm test currently still fails on origin/main's existing /popover.html 404 test case in src/__tests__/server/electron.test.ts; this PR does not touch that route.