### PR TITLE
Fix cache hit rate denominator

### DIFF
--- a/src/__tests__/client/cacheCalculations.test.ts
+++ b/src/__tests__/client/cacheCalculations.test.ts
@@ -2,17 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { cacheHitRate, costSavedByCache } from '../../client/utils/cacheCalculations.js';
 
 describe('cacheHitRate', () => {
-  it('returns 0 when input tokens is 0', () => {
-    expect(cacheHitRate(1000, 0)).toBe(0);
+  it('calculates hit rate from all input-like tokens', () => {
+    expect(cacheHitRate(500, 1000)).toBeCloseTo((500 / 1500) * 100, 5);
   });
 
-  it('calculates hit rate against all input tokens', () => {
-    // cached input is already part of input_tokens, so do not add it again.
-    expect(cacheHitRate(500, 1000)).toBe(50);
+  it('stays below 100% when cache reads exceed fresh input', () => {
+    expect(cacheHitRate(300_000, 10_000)).toBeCloseTo(96.774, 3);
   });
 
-  it('does not dilute the hit rate by adding cached input to input again', () => {
-    expect(cacheHitRate(500, 1000)).not.toBeCloseTo((500 / 1500) * 100, 5);
+  it('returns 100% when only cached input is present', () => {
+    expect(cacheHitRate(1000, 0)).toBe(100);
   });
 
   it('returns 0 when both are 0', () => {

--- a/src/client/utils/cacheCalculations.ts
+++ b/src/client/utils/cacheCalculations.ts
@@ -1,6 +1,7 @@
 export function cacheHitRate(cacheReadTokens: number, inputTokens: number): number {
-  if (inputTokens === 0) return 0;
-  return (cacheReadTokens / inputTokens) * 100;
+  const totalInputTokens = inputTokens + cacheReadTokens;
+  if (totalInputTokens === 0) return 0;
+  return (cacheReadTokens / totalInputTokens) * 100;
 }
 
 export function tokensSavedByCache(cacheReadTokens: number): number {


### PR DESCRIPTION
## Summary
- fix dashboard cache hit rate to use `cacheRead / (input + cacheRead)` instead of `cacheRead / input`
- keep the dashboard denominator aligned with the tray popover behavior
- update regression coverage for cache reads that exceed fresh input, including the 3000% class of reports

## Why
Cache read tokens are reported separately from fresh input for supported assistants. When a session reuses a large cached prefix and has little fresh input, dividing cache reads by fresh input can show impossible hit rates such as 3000%. The new formula treats the metric as the cached share of input-like tokens, so it remains bounded from 0-100%.

## Verification
- `npm test -- src/__tests__/client/cacheCalculations.test.ts`
- `npm run typecheck`
- `npm test`
