### PR TITLE
Align token accounting with ccusage semantics

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -258,17 +258,19 @@ function getTrayAgentKey(agents) {
 
 function applyTraySnapshot(snapshot) {
   const totalTokens = Number(snapshot && snapshot.totalTokens) || 0;
+  const totalInput = Number(snapshot && snapshot.totalInput) || 0;
   const totalCost = Number(snapshot && snapshot.totalCost) || 0;
   const totalCacheRead = Number(snapshot && snapshot.totalCacheRead) || 0;
   const today = snapshot && snapshot.today;
   const agentKey = snapshot && snapshot.agentKey;
 
-  lastTraySnapshot = { today, agentKey, totalTokens, totalCost, totalCacheRead };
+  lastTraySnapshot = { today, agentKey, totalTokens, totalInput, totalCost, totalCacheRead };
 
   const tokenStr = formatTokens(totalTokens);
   sendTrayCommand('title:' + tokenStr);
 
-  const cacheRate = totalTokens > 0 ? ((totalCacheRead / totalTokens) * 100).toFixed(1) : '0.0';
+  const cacheInput = totalInput + totalCacheRead;
+  const cacheRate = cacheInput > 0 ? ((totalCacheRead / cacheInput) * 100).toFixed(1) : '0.0';
   sendTrayCommand('tooltip:TokenDash - ' + tokenStr + ' tokens today ($' + totalCost.toFixed(2) + ') | cache: ' + cacheRate + '%');
 }
 
@@ -337,7 +339,7 @@ function updateTrayBadge() {
         return;
       }
 
-      applyTraySnapshot({ today, agentKey, totalTokens, totalCost, totalCacheRead });
+      applyTraySnapshot({ today, agentKey, totalTokens, totalInput, totalCost, totalCacheRead });
     })
     .catch((err) => {
       if (err.code !== 'ECONNREFUSED') {

--- a/public/popover.html
+++ b/public/popover.html
@@ -768,6 +768,7 @@
         today: todayStr,
         agentKey: selectedAgents.slice().sort().join(','),
         totalTokens: totalTokens,
+        totalInput: totalInput,
         totalCost: totalCost,
         totalCacheRead: totalCacheRead
       };

--- a/src/__tests__/client/modelAggregation.test.ts
+++ b/src/__tests__/client/modelAggregation.test.ts
@@ -28,7 +28,7 @@ describe('modelTokenMode', () => {
     expect(modelTokenMode(entry)).toBe('inputOutput');
   });
 
-  it('returns withCache when totalTokens is closer to input+output+cacheRead', () => {
+  it('returns withReadCache when totalTokens is closer to input+output+cacheRead', () => {
     const entry = makeEntry({
       totalTokens: 3_500,
       modelBreakdowns: [
@@ -38,8 +38,20 @@ describe('modelTokenMode', () => {
     });
 
     // inputOutput sum = 1000+500+500+500 = 2500, diff from 3500 = 1000
-    // withCache sum = 2500+1000 = 3500, diff from 3500 = 0
-    expect(modelTokenMode(entry)).toBe('withCache');
+    // withReadCache sum = 2500+1000 = 3500, diff from 3500 = 0
+    expect(modelTokenMode(entry)).toBe('withReadCache');
+  });
+
+  it('returns withAllCache when totalTokens includes cache creation and cache read', () => {
+    const entry = makeEntry({
+      totalTokens: 3_700,
+      modelBreakdowns: [
+        { modelName: 'claude-sonnet', inputTokens: 1_000, outputTokens: 500, cacheCreationTokens: 200, cacheReadTokens: 1_000, cost: 0 },
+        { modelName: 'gpt-5.4', inputTokens: 500, outputTokens: 500, cacheCreationTokens: 0, cacheReadTokens: 0, cost: 0 },
+      ],
+    });
+
+    expect(modelTokenMode(entry)).toBe('withAllCache');
   });
 
   it('returns inputOutput for Claude-style entries where totalTokens = input + output', () => {
@@ -78,12 +90,17 @@ describe('modelBreakdownTokens', () => {
   });
 
   it('returns input+output+cacheRead in withCache mode', () => {
-    expect(modelBreakdownTokens(breakdown, 'withCache')).toBe(1_700);
+    expect(modelBreakdownTokens(breakdown, 'withReadCache')).toBe(1_700);
+  });
+
+  it('returns input+output+cacheCreation+cacheRead in withAllCache mode', () => {
+    const withCreate = { ...breakdown, cacheCreationTokens: 300 };
+    expect(modelBreakdownTokens(withCreate, 'withAllCache')).toBe(2_000);
   });
 
   it('returns input+output when cacheRead is zero regardless of mode', () => {
     const noCache = { ...breakdown, cacheReadTokens: 0 };
     expect(modelBreakdownTokens(noCache, 'inputOutput')).toBe(1_200);
-    expect(modelBreakdownTokens(noCache, 'withCache')).toBe(1_200);
+    expect(modelBreakdownTokens(noCache, 'withReadCache')).toBe(1_200);
   });
 });

--- a/src/__tests__/server/claudeJsonlParser.test.ts
+++ b/src/__tests__/server/claudeJsonlParser.test.ts
@@ -28,11 +28,18 @@ describe('calculateCost', () => {
     expect(costWithCache).toBeCloseTo(0.30, 2);
   });
 
-  it('deducts cache read from input tokens', () => {
-    // 1M input with 500K cache read → 500K non-cached input + 500K cache read
+  it('charges input and cache read as separate usage buckets', () => {
+    // 1M input and 500K cache read match ccusage bucket semantics:
+    // input is not reduced by cache_read_input_tokens.
     const cost = calculateCost(1_000_000, 500_000, 0, 'claude-sonnet-4-6');
-    // non-cached: 500K * $3 = $1.50, cache: 500K * $0.30 = $0.15 → $1.65
-    expect(cost).toBeCloseTo(1.65, 2);
+    // input: 1M * $3 = $3, cache read: 500K * $0.30 = $0.15 -> $3.15
+    expect(cost).toBeCloseTo(3.15, 2);
+  });
+
+  it('charges cache creation separately', () => {
+    const cost = calculateCost(0, 0, 0, 'claude-sonnet-4-6', 1_000_000);
+
+    expect(cost).toBeCloseTo(3.75, 2);
   });
 });
 

--- a/src/__tests__/server/codexParser.test.ts
+++ b/src/__tests__/server/codexParser.test.ts
@@ -22,29 +22,32 @@ function writeSession(lines: unknown[]): string {
   return filepath;
 }
 
-function tokenCount(timestamp: string, totalTokens: number, outputTokens = 100): unknown {
+function tokenCount(timestamp: string, totalTokens: number, outputTokens = 100, includeLast = true): unknown {
   const inputTokens = totalTokens - outputTokens;
+  const info: Record<string, unknown> = {
+    total_token_usage: {
+      input_tokens: inputTokens,
+      cached_input_tokens: 0,
+      output_tokens: outputTokens,
+      reasoning_output_tokens: 0,
+      total_tokens: totalTokens,
+    },
+  };
+  if (includeLast) {
+    info.last_token_usage = {
+      input_tokens: inputTokens,
+      cached_input_tokens: 0,
+      output_tokens: outputTokens,
+      reasoning_output_tokens: 0,
+      total_tokens: totalTokens,
+    };
+  }
   return {
     timestamp,
     type: 'event_msg',
     payload: {
       type: 'token_count',
-      info: {
-        total_token_usage: {
-          input_tokens: inputTokens,
-          cached_input_tokens: 0,
-          output_tokens: outputTokens,
-          reasoning_output_tokens: 0,
-          total_tokens: totalTokens,
-        },
-        last_token_usage: {
-          input_tokens: inputTokens,
-          cached_input_tokens: 0,
-          output_tokens: outputTokens,
-          reasoning_output_tokens: 0,
-          total_tokens: totalTokens,
-        },
-      },
+      info,
     },
   };
 }
@@ -106,6 +109,27 @@ describe('parseCodexSession', () => {
 
     expect(session?.tokenEvents).toHaveLength(2);
     expect(session?.tokenEvents.map(ev => ev.totalTokens)).toEqual([1500, 2100]);
+  });
+
+  it('derives per-turn usage from cumulative total_token_usage when last_token_usage is missing', () => {
+    const filepath = writeSession([
+      {
+        type: 'session_meta',
+        payload: {
+          id: 'session-1',
+          cwd: '/tmp/project',
+          timestamp: '2026-05-18T00:00:00.000Z',
+        },
+      },
+      tokenCount('2026-05-18T00:00:01.000Z', 150, 50, false),
+      tokenCount('2026-05-18T00:00:02.000Z', 275, 75, false),
+    ]);
+
+    const session = parseCodexSession(filepath);
+
+    expect(session?.tokenEvents).toHaveLength(2);
+    expect(session?.tokenEvents[0]).toMatchObject({ inputTokens: 100, outputTokens: 50, totalTokens: 150 });
+    expect(session?.tokenEvents[1]).toMatchObject({ inputTokens: 100, outputTokens: 25, totalTokens: 125 });
   });
 });
 
@@ -171,21 +195,17 @@ describe('buildCodexResponsesFromSessions', () => {
     expect(entries[0].modelsUsed.sort()).toEqual(['gpt-5.4', 'gpt-5.5']);
   });
 
-  it('does not count cache reads again in Codex model totals', () => {
+  it('reports Codex input separately from cached input like ccusage', () => {
     const responses = buildCodexResponsesFromSessions([
       session('s1', '/repo/project-a', 'gpt-5.4', [event('2026-05-18T01:00:00.000Z', 1_000, 50, 900)]),
     ], { timezone: 'UTC' });
 
     const daily = responses.daily.daily[0];
-    const modelTokens = daily.modelBreakdowns.reduce((sum, model) => sum + model.inputTokens + model.outputTokens, 0);
-    const modelTokensWithCacheDoubleCounted = daily.modelBreakdowns.reduce(
-      (sum, model) => sum + model.inputTokens + model.outputTokens + model.cacheReadTokens,
-      0,
-    );
 
+    expect(daily.inputTokens).toBe(100);
+    expect(daily.cacheReadTokens).toBe(900);
     expect(daily.totalTokens).toBe(1_050);
-    expect(modelTokens).toBe(daily.totalTokens);
-    expect(modelTokensWithCacheDoubleCounted).toBe(1_950);
+    expect(daily.modelBreakdowns[0]).toMatchObject({ inputTokens: 100, cacheReadTokens: 900, outputTokens: 50 });
   });
 
   it('calculates per-model costs independently instead of splitting evenly', () => {

--- a/src/client/utils/modelAggregation.ts
+++ b/src/client/utils/modelAggregation.ts
@@ -1,12 +1,20 @@
 import type { DailyEntry } from '../../shared/types.js';
 
-export function modelTokenMode(entry: DailyEntry): 'inputOutput' | 'withCache' {
+export function modelTokenMode(entry: DailyEntry): 'inputOutput' | 'withReadCache' | 'withAllCache' {
   const inputOutput = entry.modelBreakdowns.reduce((sum, b) => sum + b.inputTokens + b.outputTokens, 0);
-  const withCache = entry.modelBreakdowns.reduce((sum, b) => sum + b.inputTokens + b.outputTokens + b.cacheReadTokens, 0);
-  return Math.abs(entry.totalTokens - inputOutput) <= Math.abs(entry.totalTokens - withCache) ? 'inputOutput' : 'withCache';
+  const withReadCache = entry.modelBreakdowns.reduce((sum, b) => sum + b.inputTokens + b.outputTokens + b.cacheReadTokens, 0);
+  const withAllCache = entry.modelBreakdowns.reduce((sum, b) => sum + b.inputTokens + b.outputTokens + b.cacheCreationTokens + b.cacheReadTokens, 0);
+  const candidates = [
+    { mode: 'inputOutput' as const, diff: Math.abs(entry.totalTokens - inputOutput) },
+    { mode: 'withReadCache' as const, diff: Math.abs(entry.totalTokens - withReadCache) },
+    { mode: 'withAllCache' as const, diff: Math.abs(entry.totalTokens - withAllCache) },
+  ];
+  return candidates.reduce((best, candidate) => candidate.diff < best.diff ? candidate : best).mode;
 }
 
-export function modelBreakdownTokens(breakdown: DailyEntry['modelBreakdowns'][number], mode: 'inputOutput' | 'withCache'): number {
+export function modelBreakdownTokens(breakdown: DailyEntry['modelBreakdowns'][number], mode: ReturnType<typeof modelTokenMode>): number {
   const base = breakdown.inputTokens + breakdown.outputTokens;
-  return mode === 'withCache' ? base + breakdown.cacheReadTokens : base;
+  if (mode === 'withAllCache') return base + breakdown.cacheCreationTokens + breakdown.cacheReadTokens;
+  if (mode === 'withReadCache') return base + breakdown.cacheReadTokens;
+  return base;
 }

--- a/src/server/claudeBlocksParser.ts
+++ b/src/server/claudeBlocksParser.ts
@@ -165,7 +165,7 @@ export function getClaudeBlocksByProject(project: string): BlockEntry[] {
         const outputTokens = usage.output_tokens;
         const cacheCreationTokens = usage.cache_creation_input_tokens;
         const cacheReadTokens = usage.cache_read_input_tokens;
-        const totalTokens = inputTokens + outputTokens + cacheReadTokens;
+        const totalTokens = inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens;
 
         if (totalTokens === 0) continue;
 
@@ -192,7 +192,7 @@ export function getClaudeBlocksByProject(project: string): BlockEntry[] {
   const blocks: BlockEntry[] = [];
   let idx = 0;
   for (const [hourKey, bucket] of hourMap) {
-    const totalTokens = bucket.inputTokens + bucket.outputTokens + bucket.cacheReadTokens;
+    const totalTokens = bucket.inputTokens + bucket.outputTokens + bucket.cacheCreationTokens + bucket.cacheReadTokens;
     blocks.push({
       id: `claude-project-${idx}`,
       startTime: `${hourKey}:00:00.000Z`,

--- a/src/server/claudeJsonlParser.ts
+++ b/src/server/claudeJsonlParser.ts
@@ -10,25 +10,26 @@ import type { DailyEntry, DailyResponse, ProjectsResponse, Totals, BlockEntry } 
 
 interface ModelPricing {
   inputPer1M: number;
+  cacheCreationPer1M: number;
   cacheReadPer1M: number;
   outputPer1M: number;
 }
 
 const MODEL_PRICING: Record<string, ModelPricing> = {
   // Claude 4.6
-  'claude-opus-4-6': { inputPer1M: 15, cacheReadPer1M: 1.50, outputPer1M: 75 },
-  'claude-sonnet-4-6': { inputPer1M: 3, cacheReadPer1M: 0.30, outputPer1M: 15 },
+  'claude-opus-4-6': { inputPer1M: 15, cacheCreationPer1M: 18.75, cacheReadPer1M: 1.50, outputPer1M: 75 },
+  'claude-sonnet-4-6': { inputPer1M: 3, cacheCreationPer1M: 3.75, cacheReadPer1M: 0.30, outputPer1M: 15 },
   // Claude 4.5
-  'claude-sonnet-4-5-20250514': { inputPer1M: 3, cacheReadPer1M: 0.30, outputPer1M: 15 },
-  'claude-haiku-4-5-20251001': { inputPer1M: 0.80, cacheReadPer1M: 0.08, outputPer1M: 4 },
+  'claude-sonnet-4-5-20250514': { inputPer1M: 3, cacheCreationPer1M: 3.75, cacheReadPer1M: 0.30, outputPer1M: 15 },
+  'claude-haiku-4-5-20251001': { inputPer1M: 0.80, cacheCreationPer1M: 1, cacheReadPer1M: 0.08, outputPer1M: 4 },
   // Older Claude models
-  'claude-3-5-sonnet-20241022': { inputPer1M: 3, cacheReadPer1M: 0.30, outputPer1M: 15 },
-  'claude-3-5-haiku-20241022': { inputPer1M: 0.80, cacheReadPer1M: 0.08, outputPer1M: 4 },
-  'claude-3-opus-20240229': { inputPer1M: 15, cacheReadPer1M: 1.50, outputPer1M: 75 },
-  'claude-3-haiku-20240307': { inputPer1M: 0.25, cacheReadPer1M: 0.03, outputPer1M: 1.25 },
+  'claude-3-5-sonnet-20241022': { inputPer1M: 3, cacheCreationPer1M: 3.75, cacheReadPer1M: 0.30, outputPer1M: 15 },
+  'claude-3-5-haiku-20241022': { inputPer1M: 0.80, cacheCreationPer1M: 1, cacheReadPer1M: 0.08, outputPer1M: 4 },
+  'claude-3-opus-20240229': { inputPer1M: 15, cacheCreationPer1M: 18.75, cacheReadPer1M: 1.50, outputPer1M: 75 },
+  'claude-3-haiku-20240307': { inputPer1M: 0.25, cacheCreationPer1M: 0.30, cacheReadPer1M: 0.03, outputPer1M: 1.25 },
 };
 
-const DEFAULT_PRICING: ModelPricing = { inputPer1M: 3, cacheReadPer1M: 0.30, outputPer1M: 15 };
+const DEFAULT_PRICING: ModelPricing = { inputPer1M: 3, cacheCreationPer1M: 3.75, cacheReadPer1M: 0.30, outputPer1M: 15 };
 
 function getPricing(model: string): ModelPricing {
   // Try exact match first, then prefix match
@@ -40,12 +41,16 @@ function getPricing(model: string): ModelPricing {
   return DEFAULT_PRICING;
 }
 
-export function calculateCost(inputTokens: number, cacheReadTokens: number, outputTokens: number, model: string): number {
+export function calculateCost(inputTokens: number, cacheReadTokens: number, outputTokens: number, model: string, cacheCreationTokens = 0): number {
   const p = getPricing(model);
-  const nonCachedInput = Math.max(inputTokens - cacheReadTokens, 0);
-  return (nonCachedInput / 1_000_000) * p.inputPer1M
+  return (inputTokens / 1_000_000) * p.inputPer1M
+    + (cacheCreationTokens / 1_000_000) * p.cacheCreationPer1M
     + (cacheReadTokens / 1_000_000) * p.cacheReadPer1M
     + (outputTokens / 1_000_000) * p.outputPer1M;
+}
+
+function totalClaudeTokens(inputTokens: number, outputTokens: number, cacheCreationTokens: number, cacheReadTokens: number): number {
+  return inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens;
 }
 
 // ---------------------------------------------------------------------------
@@ -189,7 +194,7 @@ function parseAllSessions(project?: string | null): ParsedUsage[] {
         const outputTokens = usage.output_tokens || 0;
         const cacheCreationTokens = usage.cache_creation_input_tokens || 0;
         const cacheReadTokens = usage.cache_read_input_tokens || 0;
-        const totalTokens = inputTokens + outputTokens + cacheReadTokens;
+        const totalTokens = totalClaudeTokens(inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens);
 
         if (totalTokens === 0) continue;
 
@@ -305,9 +310,9 @@ export function getDailyResponse(project?: string | null, tz = DEFAULT_TZ): Dail
     agg.outputTokens += e.outputTokens;
     agg.cacheCreationTokens += e.cacheCreationTokens;
     agg.cacheReadTokens += e.cacheReadTokens;
-    agg.totalTokens += e.inputTokens + e.outputTokens + e.cacheReadTokens;
+    agg.totalTokens += totalClaudeTokens(e.inputTokens, e.outputTokens, e.cacheCreationTokens, e.cacheReadTokens);
 
-    const cost = calculateCost(e.inputTokens, e.cacheReadTokens, e.outputTokens, e.model);
+    const cost = calculateCost(e.inputTokens, e.cacheReadTokens, e.outputTokens, e.model, e.cacheCreationTokens);
     agg.totalCost += cost;
 
     if (!agg.models.has(e.model)) {
@@ -359,9 +364,9 @@ export function getProjectsResponse(tz = DEFAULT_TZ): ProjectsResponse {
     agg.outputTokens += e.outputTokens;
     agg.cacheCreationTokens += e.cacheCreationTokens;
     agg.cacheReadTokens += e.cacheReadTokens;
-    agg.totalTokens += e.inputTokens + e.outputTokens + e.cacheReadTokens;
+    agg.totalTokens += totalClaudeTokens(e.inputTokens, e.outputTokens, e.cacheCreationTokens, e.cacheReadTokens);
 
-    const cost = calculateCost(e.inputTokens, e.cacheReadTokens, e.outputTokens, e.model);
+    const cost = calculateCost(e.inputTokens, e.cacheReadTokens, e.outputTokens, e.model, e.cacheCreationTokens);
     agg.totalCost += cost;
 
     if (!agg.models.has(e.model)) {
@@ -405,14 +410,14 @@ export function getBlocksResponse(project?: string | null, tz = DEFAULT_TZ): { b
     bucket.outputTokens += e.outputTokens;
     bucket.cacheCreationTokens += e.cacheCreationTokens;
     bucket.cacheReadTokens += e.cacheReadTokens;
-    bucket.costUSD += calculateCost(e.inputTokens, e.cacheReadTokens, e.outputTokens, e.model);
+    bucket.costUSD += calculateCost(e.inputTokens, e.cacheReadTokens, e.outputTokens, e.model, e.cacheCreationTokens);
     bucket.models.add(e.model);
   }
 
   const blocks: BlockEntry[] = [];
   let idx = 0;
   for (const [hourKey, bucket] of hourMap) {
-    const totalTokens = bucket.inputTokens + bucket.outputTokens + bucket.cacheReadTokens;
+    const totalTokens = totalClaudeTokens(bucket.inputTokens, bucket.outputTokens, bucket.cacheCreationTokens, bucket.cacheReadTokens);
     blocks.push({
       id: `claude-${idx}`,
       startTime: `${hourKey}:00:00`,

--- a/src/server/codexParser.ts
+++ b/src/server/codexParser.ts
@@ -19,7 +19,7 @@ const TokenUsageSchema = z.object({
 
 const TokenCountInfoSchema = z.object({
   total_token_usage: TokenUsageSchema,
-  last_token_usage: TokenUsageSchema,
+  last_token_usage: TokenUsageSchema.optional(),
 }).nullable().default(null);
 
 const TokenCountPayloadSchema = z.object({
@@ -69,14 +69,22 @@ interface AggregateBucket {
   models: Map<string, TokenAccumulator>;
 }
 
-function tokenUsageKey(usage: z.infer<typeof TokenUsageSchema>): string {
-  return [
-    usage.input_tokens,
-    usage.cached_input_tokens,
-    usage.output_tokens,
-    usage.reasoning_output_tokens,
-    usage.total_tokens,
-  ].join(':');
+function subtractTokenUsage(
+  current: z.infer<typeof TokenUsageSchema>,
+  previous: z.infer<typeof TokenUsageSchema> | null,
+): ParsedTokenEvent {
+  return {
+    timestamp: '',
+    inputTokens: Math.max(0, current.input_tokens - (previous?.input_tokens ?? 0)),
+    cachedInputTokens: Math.max(0, current.cached_input_tokens - (previous?.cached_input_tokens ?? 0)),
+    outputTokens: Math.max(0, current.output_tokens - (previous?.output_tokens ?? 0)),
+    reasoningOutputTokens: Math.max(0, current.reasoning_output_tokens - (previous?.reasoning_output_tokens ?? 0)),
+    totalTokens: Math.max(0, current.total_tokens - (previous?.total_tokens ?? 0)),
+  };
+}
+
+function displayInputTokens(inputTokens: number, cachedInputTokens: number): number {
+  return Math.max(0, inputTokens - cachedInputTokens);
 }
 
 // ---------------------------------------------------------------------------
@@ -152,7 +160,9 @@ export function parseCodexSession(filepath: string): ParsedSession | null {
   let model = '';
   let createdAt = '';
   const tokenEvents: ParsedTokenEvent[] = [];
+  let previousTotalUsage: z.infer<typeof TokenUsageSchema> | null = null;
   const seenTotalUsageSnapshots = new Set<string>();
+  const seenUsageEvents = new Set<string>();
 
   for (const line of lines) {
     const trimmed = line.trim();
@@ -193,19 +203,45 @@ export function parseCodexSession(filepath: string): ParsedSession | null {
         }
         const info = parseResult.data.info;
         if (!info) continue;
-        const totalUsageKey = tokenUsageKey(info.total_token_usage);
+        const totalUsageKey = [
+          info.total_token_usage.input_tokens,
+          info.total_token_usage.cached_input_tokens,
+          info.total_token_usage.output_tokens,
+          info.total_token_usage.reasoning_output_tokens,
+          info.total_token_usage.total_tokens,
+        ].join(':');
         if (seenTotalUsageSnapshots.has(totalUsageKey)) continue;
         seenTotalUsageSnapshots.add(totalUsageKey);
 
-        const last = info.last_token_usage;
-        tokenEvents.push({
+        const last = info.last_token_usage ?? info.total_token_usage;
+        const rawEvent = info.last_token_usage
+          ? subtractTokenUsage(last, null)
+          : subtractTokenUsage(last, previousTotalUsage);
+        previousTotalUsage = info.total_token_usage;
+
+        if (rawEvent.inputTokens === 0 && rawEvent.cachedInputTokens === 0 && rawEvent.outputTokens === 0 && rawEvent.reasoningOutputTokens === 0) {
+          continue;
+        }
+
+        const event = {
+          ...rawEvent,
           timestamp,
-          inputTokens: last.input_tokens,
-          cachedInputTokens: last.cached_input_tokens,
-          outputTokens: last.output_tokens,
-          reasoningOutputTokens: last.reasoning_output_tokens,
-          totalTokens: last.total_tokens,
-        });
+          cachedInputTokens: Math.min(rawEvent.cachedInputTokens, rawEvent.inputTokens),
+        };
+        const eventKey = [
+          timestamp,
+          model,
+          event.inputTokens,
+          event.cachedInputTokens,
+          event.outputTokens,
+          event.reasoningOutputTokens,
+          event.totalTokens,
+        ].join(':');
+        if (seenUsageEvents.has(eventKey)) {
+          continue;
+        }
+        seenUsageEvents.add(eventKey);
+        tokenEvents.push(event);
       }
     }
   }
@@ -279,6 +315,13 @@ function addAcc(a: TokenAccumulator, ev: ParsedTokenEvent): void {
   a.totalTokens += ev.totalTokens;
 }
 
+function displayAcc(acc: TokenAccumulator): TokenAccumulator {
+  return {
+    ...acc,
+    inputTokens: displayInputTokens(acc.inputTokens, acc.cachedInputTokens),
+  };
+}
+
 function mergeAcc(a: TokenAccumulator, b: TokenAccumulator): void {
   a.inputTokens += b.inputTokens;
   a.cachedInputTokens += b.cachedInputTokens;
@@ -295,16 +338,17 @@ function addAccToBucket(bucket: AggregateBucket, ev: ParsedTokenEvent, model: st
 }
 
 function accToEntry(date: string, acc: TokenAccumulator, modelAccs: Map<string, TokenAccumulator>): DailyEntry {
+  const display = displayAcc(acc);
   const modelNames = [...modelAccs.keys()];
   const modelBreakdowns = buildModelBreakdowns(modelAccs);
   const totalCost = modelBreakdowns.reduce((sum, model) => sum + model.cost, 0);
   return {
     date,
-    inputTokens: acc.inputTokens,
-    outputTokens: acc.outputTokens,
+    inputTokens: display.inputTokens,
+    outputTokens: display.outputTokens,
     cacheCreationTokens: 0,
-    cacheReadTokens: acc.cachedInputTokens,
-    totalTokens: acc.totalTokens,
+    cacheReadTokens: display.cachedInputTokens,
+    totalTokens: display.totalTokens,
     totalCost,
     modelsUsed: modelNames,
     modelBreakdowns,
@@ -312,14 +356,17 @@ function accToEntry(date: string, acc: TokenAccumulator, modelAccs: Map<string, 
 }
 
 function buildModelBreakdowns(modelAccs: Map<string, TokenAccumulator>): ModelBreakdown[] {
-  return [...modelAccs.entries()].map(([modelName, acc]) => ({
-    modelName,
-    inputTokens: acc.inputTokens,
-    outputTokens: acc.outputTokens,
-    cacheCreationTokens: 0,
-    cacheReadTokens: acc.cachedInputTokens,
-    cost: calculateCost(acc, new Set([modelName])),
-  }));
+  return [...modelAccs.entries()].map(([modelName, acc]) => {
+    const display = displayAcc(acc);
+    return {
+      modelName,
+      inputTokens: display.inputTokens,
+      outputTokens: display.outputTokens,
+      cacheCreationTokens: 0,
+      cacheReadTokens: display.cachedInputTokens,
+      cost: calculateCost(acc, new Set([modelName])),
+    };
+  });
 }
 
 type GroupKey = string;
@@ -396,7 +443,7 @@ function buildDailyResponse(sessions: ParsedSession[], options?: Partial<Aggrega
   return {
     daily,
     totals: {
-      inputTokens: totalsAcc.inputTokens,
+      inputTokens: displayInputTokens(totalsAcc.inputTokens, totalsAcc.cachedInputTokens),
       outputTokens: totalsAcc.outputTokens,
       cacheCreationTokens: 0,
       cacheReadTokens: totalsAcc.cachedInputTokens,
@@ -459,7 +506,7 @@ function buildBlocksResponse(sessions: ParsedSession[], options?: Partial<Aggreg
       isGap: false,
       entries: acc.totalTokens > 0 ? 1 : 0,
       tokenCounts: {
-        inputTokens: acc.inputTokens,
+        inputTokens: displayInputTokens(acc.inputTokens, acc.cachedInputTokens),
         outputTokens: acc.outputTokens,
         cacheCreationInputTokens: 0,
         cacheReadInputTokens: acc.cachedInputTokens,


### PR DESCRIPTION
## Summary
- Align Claude Code totals with ccusage by including cache creation and cache read in total token accounting.
- Treat Claude input, cache creation, cache read, and output as independent cost buckets.
- Align Codex display semantics with ccusage: keep upstream total_tokens, show non-cached input separately from cache read, and derive deltas from cumulative usage when last_token_usage is missing.
- Update model aggregation and tray cache-rate snapshot handling for the aligned token semantics.

## Verification
- npm test -- src/__tests__/server/claudeJsonlParser.test.ts src/__tests__/server/codexParser.test.ts src/__tests__/client/modelAggregation.test.ts src/__tests__/client/cacheCalculations.test.ts
- npm run typecheck
- npm test
- npm run build
- npm run test:e2e