### PR TITLE
Keep menu bar dashboard aligned with CLI service

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -19,6 +19,8 @@ try {
 
 const { formatTokens } = require('./trayBadge.cjs');
 const { checkForUpdates, downloadUpdateAsset } = require('./updateService.cjs');
+const { syncNpmPackageVersion } = require('./npmSync.cjs');
+const { findCompatibleServer, getDashboardUrl } = require('./serverReuse.cjs');
 
 // Resolve trayHelper binary: extract from asar if needed
 function resolveTrayHelperPath() {
@@ -52,6 +54,7 @@ let server = null;
 let trayProcess = null;
 let selectedAgents = null; // null = use all available agents
 let serverPort = parseInt(process.env.TOKENDASH_PORT || '3456', 10);
+let dashboardUrl = getDashboardUrl(serverPort);
 let lastUpdateInfo = null;
 let isDownloadingUpdate = false;
 const POPOVER_WIDTH = 380;
@@ -97,6 +100,10 @@ function fetchJson(url) {
       });
     }).on('error', reject);
   });
+}
+
+function getServerBaseUrl() {
+  return dashboardUrl || getDashboardUrl(serverPort);
 }
 
 function getAppInfo() {
@@ -245,7 +252,8 @@ function updateTrayBadge() {
   const d = new Date(); const today = d.getFullYear() + "-" + String(d.getMonth()+1).padStart(2,"0") + "-" + String(d.getDate()).padStart(2,"0");
 
   // Fetch agents list, then fetch daily data for each agent in parallel
-  fetchJson(`http://localhost:${serverPort}/api/agents`)
+  const serverBaseUrl = getServerBaseUrl();
+  fetchJson(`${serverBaseUrl}/api/agents`)
     .then((agentData) => {
       let agents = (agentData && Array.isArray(agentData.available)) ? agentData.available : ['claude'];
       if (agents.length === 0) {
@@ -262,7 +270,7 @@ function updateTrayBadge() {
       const agentKey = getTrayAgentKey(agents);
       return Promise.all(
         agents.map(agent =>
-          fetchJson(`http://localhost:${serverPort}/api/daily?agent=${agent}`)
+          fetchJson(`${serverBaseUrl}/api/daily?agent=${agent}`)
             .catch(() => null)
         )
       ).then(results => ({ agentKey, results }));
@@ -350,7 +358,7 @@ function createPopoverWindow() {
     },
   });
 
-  popover.loadURL(`http://localhost:${serverPort}/popover.html`);
+  popover.loadURL(`${getServerBaseUrl()}/popover.html`);
 
   popover.on('blur', () => {
     popover.hide();
@@ -366,8 +374,7 @@ function createPopoverWindow() {
 
 function registerIpcHandlers() {
   ipcMain.handle('tokendash:open-dashboard', (_event, url) => {
-    const target = typeof url === 'string' && url.length > 0 ? url : `http://localhost:${serverPort}`;
-    return shell.openExternal(target);
+    return shell.openExternal(getServerBaseUrl());
   });
 
   ipcMain.handle('tokendash:get-app-info', () => {
@@ -462,15 +469,34 @@ app.whenReady().then(async () => {
     if (server) server.close();
   });
 
-  // Create and bind Express server
-  // Pass dist/ directory so createApp resolves client assets correctly
+  const currentVersion = getAppInfo().version;
+  syncNpmPackageVersion(PACKAGE_NAME, currentVersion).then((result) => {
+    if (!result || result.ok) return;
+    console.warn('Could not sync npm package version:', result.error || 'unknown error');
+  }).catch((error) => {
+    console.warn('Could not sync npm package version:', error instanceof Error ? error.message : String(error));
+  });
+
+  const existingServer = await findCompatibleServer(serverPort, currentVersion, PACKAGE_NAME);
+  if (existingServer) {
+    serverPort = existingServer.port;
+    dashboardUrl = existingServer.dashboardUrl;
+    console.log(`tokendash reusing CLI server on ${dashboardUrl}`);
+    startTrayHelper();
+    createPopoverWindow();
+    return;
+  }
+
+  // Create and bind Express server.
+  // Pass dist/ directory so createApp resolves client assets correctly.
   const distDir = path.join(__dirname, '..', 'dist');
   const expressApp = createApp(serverPort, distDir);
   try {
     const result = await listenWithFallback(expressApp, serverPort);
     server = result.server;
     serverPort = result.port;
-    console.log(`tokendash running on http://localhost:${result.port}`);
+    dashboardUrl = getDashboardUrl(result.port);
+    console.log(`tokendash running on ${dashboardUrl}`);
   } catch (err) {
     console.error('Failed to start server:', err);
     app.quit();

--- a/electron/npmSync.cjs
+++ b/electron/npmSync.cjs
@@ -1,0 +1,62 @@
+const { spawn } = require('node:child_process');
+
+function normalizeVersion(version) {
+  return String(version || '').trim().replace(/^v/, '');
+}
+
+function shouldInstallPackage(installedVersion, targetVersion) {
+  const installed = normalizeVersion(installedVersion);
+  const target = normalizeVersion(targetVersion);
+  return Boolean(target) && installed !== target;
+}
+
+function buildNpmInstallArgs(packageName, version) {
+  return ['install', '-g', `${packageName}@${version}`];
+}
+
+function runCommand(command, args) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    child.on('error', (error) => resolve({ ok: false, stdout, stderr, error }));
+    child.on('close', (code) => resolve({ ok: code === 0, code, stdout, stderr }));
+  });
+}
+
+async function getInstalledPackageVersion(packageName) {
+  const result = await runCommand('npm', ['list', '-g', packageName, '--depth=0', '--json']);
+  if (!result.ok) return null;
+  try {
+    const data = JSON.parse(result.stdout);
+    return normalizeVersion(data && data.dependencies && data.dependencies[packageName] && data.dependencies[packageName].version);
+  } catch (_) {
+    return null;
+  }
+}
+
+async function syncNpmPackageVersion(packageName, version) {
+  const installedVersion = await getInstalledPackageVersion(packageName);
+  if (!shouldInstallPackage(installedVersion, version)) {
+    return { ok: true, installedVersion, targetVersion: version, changed: false };
+  }
+
+  const result = await runCommand('npm', buildNpmInstallArgs(packageName, version));
+  return {
+    ok: result.ok,
+    installedVersion,
+    targetVersion: version,
+    changed: result.ok,
+    error: result.ok ? null : (result.error ? result.error.message : result.stderr || `npm exited with ${result.code}`),
+  };
+}
+
+module.exports = {
+  buildNpmInstallArgs,
+  getInstalledPackageVersion,
+  shouldInstallPackage,
+  syncNpmPackageVersion,
+};

--- a/electron/serverReuse.cjs
+++ b/electron/serverReuse.cjs
@@ -1,0 +1,59 @@
+const http = require('node:http');
+
+function normalizePort(port) {
+  const value = parseInt(String(port || ''), 10);
+  return Number.isInteger(value) && value > 0 ? value : 3456;
+}
+
+function getDashboardUrl(port) {
+  return `http://localhost:${normalizePort(port)}`;
+}
+
+function isCompatibleServerInfo(info, expectedVersion, expectedPackageName) {
+  return Boolean(
+    info &&
+    info.packageName === expectedPackageName &&
+    String(info.version || '').replace(/^v/, '') === String(expectedVersion || '').replace(/^v/, '')
+  );
+}
+
+function fetchJson(url, timeoutMs = 1000) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        if (res.statusCode && res.statusCode >= 400) {
+          reject(new Error(`HTTP ${res.statusCode}`));
+          return;
+        }
+        try { resolve(JSON.parse(data)); }
+        catch (error) { reject(error); }
+      });
+    });
+
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error('Request timed out'));
+    });
+    req.on('error', reject);
+  });
+}
+
+async function findCompatibleServer(preferredPort, expectedVersion, expectedPackageName) {
+  const port = normalizePort(preferredPort);
+  try {
+    const info = await fetchJson(`${getDashboardUrl(port)}/api/app-info`);
+    if (isCompatibleServerInfo(info, expectedVersion, expectedPackageName)) {
+      return { port, dashboardUrl: info.dashboardUrl || getDashboardUrl(port), info };
+    }
+  } catch (_) {}
+  return null;
+}
+
+module.exports = {
+  fetchJson,
+  findCompatibleServer,
+  getDashboardUrl,
+  isCompatibleServerInfo,
+  normalizePort,
+};

--- a/src/__tests__/server/electron.test.ts
+++ b/src/__tests__/server/electron.test.ts
@@ -15,6 +15,14 @@ const { compareVersions, getReleaseUpdateInfo, selectMacDmgAsset } = require('..
   getReleaseUpdateInfo: (release: any, currentVersion: string, arch?: string) => any;
   selectMacDmgAsset: (assets: any[], arch?: string) => any;
 };
+const { buildNpmInstallArgs, shouldInstallPackage } = require('../../../electron/npmSync.cjs') as {
+  buildNpmInstallArgs: (packageName: string, version: string) => string[];
+  shouldInstallPackage: (installedVersion: string | null | undefined, targetVersion: string) => boolean;
+};
+const { getDashboardUrl, isCompatibleServerInfo } = require('../../../electron/serverReuse.cjs') as {
+  getDashboardUrl: (port: number | string | null | undefined) => string;
+  isCompatibleServerInfo: (info: any, expectedVersion: string, expectedPackageName: string) => boolean;
+};
 
 describe('createApp', () => {
   it('returns an Express app', () => {
@@ -33,6 +41,25 @@ describe('createApp', () => {
     try {
       const data = await fetchJson(`http://localhost:${port}/api/agents`);
       expect(data).toHaveProperty('available');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('exposes package version and dashboard URL for CLI/Electron coordination', async () => {
+    const app = createApp(4567);
+    const server = app.listen(0);
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('no address');
+    const port = address.port;
+
+    try {
+      const data = await fetchJson(`http://localhost:${port}/api/app-info`);
+      expect(data).toMatchObject({
+        packageName: '@zhangferry-dev/tokendash',
+        version: '1.6.0',
+        dashboardUrl: `http://localhost:${port}`,
+      });
     } finally {
       server.close();
     }
@@ -85,6 +112,22 @@ describe('resolveStaticAssetBaseDir', () => {
       baseDir: '/opt/homebrew/lib/node_modules/@zhangferry-dev/tokendash/dist',
       isProduction: true,
     });
+  });
+
+  it('reads package metadata from bundled Electron server output', async () => {
+    const app = createApp(7890, '/app/dist');
+    const server = app.listen(0);
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('no address');
+    const port = address.port;
+
+    try {
+      const data = await fetchJson(`http://localhost:${port}/api/app-info`);
+      expect(data.version).toBe('1.6.0');
+      expect(data.dashboardUrl).toBe(`http://localhost:${port}`);
+    } finally {
+      server.close();
+    }
   });
 
   it('keeps explicit production base directories unchanged', () => {
@@ -215,6 +258,36 @@ describe('updateService', () => {
       size: 123,
       url: 'https://example.com/TokenDash.dmg',
     });
+  });
+});
+
+describe('npm package sync helpers', () => {
+  it('installs the exact app version of the npm package', () => {
+    expect(buildNpmInstallArgs('@zhangferry-dev/tokendash', '1.6.0')).toEqual([
+      'install',
+      '-g',
+      '@zhangferry-dev/tokendash@1.6.0',
+    ]);
+  });
+
+  it('skips npm install only when the installed version already matches', () => {
+    expect(shouldInstallPackage('1.6.0', '1.6.0')).toBe(false);
+    expect(shouldInstallPackage('1.5.0', '1.6.0')).toBe(true);
+    expect(shouldInstallPackage(null, '1.6.0')).toBe(true);
+  });
+});
+
+describe('Electron server reuse helpers', () => {
+  it('builds the dashboard URL from the active server port', () => {
+    expect(getDashboardUrl(3456)).toBe('http://localhost:3456');
+    expect(getDashboardUrl('4567')).toBe('http://localhost:4567');
+    expect(getDashboardUrl(undefined)).toBe('http://localhost:3456');
+  });
+
+  it('reuses only matching TokenDash servers', () => {
+    expect(isCompatibleServerInfo({ packageName: '@zhangferry-dev/tokendash', version: '1.6.0' }, '1.6.0', '@zhangferry-dev/tokendash')).toBe(true);
+    expect(isCompatibleServerInfo({ packageName: '@zhangferry-dev/tokendash', version: '1.5.0' }, '1.6.0', '@zhangferry-dev/tokendash')).toBe(false);
+    expect(isCompatibleServerInfo({ packageName: 'other', version: '1.6.0' }, '1.6.0', '@zhangferry-dev/tokendash')).toBe(false);
   });
 });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -23,11 +23,23 @@ const CLI_USAGE = [
   '  tokendash --tray [--port <number>]',
 ].join('\n');
 
+const PACKAGE_NAME = '@zhangferry-dev/tokendash';
+
 function getPackageVersion(): string {
   const __filename = fileURLToPath(import.meta.url);
   const __dirname = dirname(__filename);
-  const packageJson = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf8')) as { version?: string };
-  return packageJson.version ?? 'unknown';
+  const packageJsonPaths = [
+    join(__dirname, '..', '..', 'package.json'), // dist/server/index.js
+    join(__dirname, '..', 'package.json'), // dist/electron-server.cjs
+  ];
+
+  for (const packageJsonPath of packageJsonPaths) {
+    if (!existsSync(packageJsonPath)) continue;
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { version?: string };
+    if (packageJson.version) return packageJson.version;
+  }
+
+  return 'unknown';
 }
 
 function exitWithCliError(message: string): never {
@@ -165,7 +177,11 @@ export function createApp(_port: number, baseDir?: string): Express {
   const router = express.Router();
 
   // Register API routes
-  registerApiRoutes(router);
+  registerApiRoutes(router, {
+    packageName: PACKAGE_NAME,
+    version: getPackageVersion(),
+    dashboardUrl: `http://localhost:${resolvePort(_port)}`,
+  });
   app.use('/api', router);
 
   const { baseDir: _baseDir, isProduction } = resolveStaticAssetBaseDir(import.meta.url, baseDir);

--- a/src/server/routes/api.ts
+++ b/src/server/routes/api.ts
@@ -9,6 +9,12 @@ import { detectAvailableAgents } from '../agentDetection.js';
 import { isOpenClawAccessible } from '../openclawParser.js';
 import { isOpencodeAccessible } from '../opencodeParser.js';
 
+export interface AppInfo {
+  packageName: string;
+  version: string;
+  dashboardUrl?: string;
+}
+
 function getAgents(_req: Request, res: Response): void {
   try {
     const agents = detectAvailableAgents();
@@ -24,7 +30,18 @@ function getAgents(_req: Request, res: Response): void {
   }
 }
 
-export function registerApiRoutes(router: Router): void {
+function getAppInfo(info: AppInfo): (_req: Request, res: Response) => void {
+  return (req: Request, res: Response) => {
+    const host = req.get('host');
+    res.json({
+      ...info,
+      dashboardUrl: host ? `${req.protocol}://${host}` : info.dashboardUrl,
+    });
+  };
+}
+
+export function registerApiRoutes(router: Router, appInfo: AppInfo): void {
+  router.get('/app-info', getAppInfo(appInfo));
   router.get('/agents', getAgents);
   router.get('/daily', getDaily);
   router.get('/monthly', getMonthly);


### PR DESCRIPTION
## Summary
- Add `/api/app-info` so TokenDash servers expose package/version and their active dashboard URL.
- Make the macOS menu bar app reuse a compatible same-version CLI/npm server instead of falling back to a separate bundled service.
- Sync the globally installed npm package to the DMG app version in the background and cover the coordination helpers with regression tests.

## Test Plan
- [x] `npx vitest run src/__tests__/server/electron.test.ts`
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `PORT=4566 node bin/tokendash.js --no-open` + `/api/app-info` smoke test
- [x] `npm pack --dry-run`