### PR TITLE
Keep update checks working after API rate limits

### DIFF
--- a/electron/updateService.cjs
+++ b/electron/updateService.cjs
@@ -30,6 +30,35 @@ function fetchHttpsJson(url) {
   });
 }
 
+function fetchLatestReleaseUrl(repo) {
+  const url = `https://github.com/${repo}/releases/latest`;
+  return new Promise((resolve, reject) => {
+    const opts = new URL(url);
+    const reqOpts = {
+      hostname: opts.hostname,
+      path: opts.pathname + opts.search,
+      method: 'HEAD',
+      headers: {
+        'User-Agent': 'TokenDash',
+      },
+    };
+
+    https.request(reqOpts, (res) => {
+      if ([301, 302, 303, 307, 308].includes(res.statusCode) && res.headers.location) {
+        resolve(new URL(res.headers.location, url).toString());
+        return;
+      }
+
+      if (res.statusCode && res.statusCode >= 400) {
+        reject(new Error(`HTTP ${res.statusCode}`));
+        return;
+      }
+
+      resolve(url);
+    }).on('error', reject).end();
+  });
+}
+
 function compareVersions(a, b) {
   const aParts = String(a).replace(/^v/, '').split(/[.-]/).map((part) => parseInt(part, 10) || 0);
   const bParts = String(b).replace(/^v/, '').split(/[.-]/).map((part) => parseInt(part, 10) || 0);
@@ -78,9 +107,50 @@ function getReleaseUpdateInfo(release, currentVersion, arch = process.arch) {
   };
 }
 
-async function checkForUpdates({ repo, currentVersion, arch = process.arch }) {
-  const release = await fetchHttpsJson(`https://api.github.com/repos/${repo}/releases/latest`);
-  return getReleaseUpdateInfo(release, currentVersion, arch);
+function buildDmgAssetFromVersion(repo, tagName, arch = process.arch) {
+  const version = String(tagName || '').replace(/^v/, '');
+  const archSuffix = arch === 'arm64' ? 'arm64' : arch === 'x64' ? 'x64' : 'universal';
+  const name = `TokenDash-${version}-${archSuffix}.dmg`;
+
+  return {
+    name,
+    size: 0,
+    url: `https://github.com/${repo}/releases/download/${tagName}/${name}`,
+  };
+}
+
+function getRedirectReleaseUpdateInfo(repo, releaseUrl, currentVersion, arch = process.arch) {
+  const parsedUrl = new URL(releaseUrl);
+  const tagMatch = parsedUrl.pathname.match(/\/releases\/tag\/([^/]+)\/?$/);
+  if (!tagMatch) throw new Error('Unable to determine the latest release tag.');
+
+  const tagName = decodeURIComponent(tagMatch[1]);
+  const latestVersion = tagName.replace(/^v/, '');
+  const upToDate = compareVersions(currentVersion, latestVersion) >= 0;
+
+  return {
+    currentVersion,
+    latestVersion,
+    upToDate,
+    releaseUrl: parsedUrl.toString(),
+    asset: upToDate ? null : buildDmgAssetFromVersion(repo, tagName, arch),
+  };
+}
+
+async function checkForUpdates({
+  repo,
+  currentVersion,
+  arch = process.arch,
+  fetchReleaseJson = fetchHttpsJson,
+  fetchLatestReleaseUrl: fetchLatestReleaseUrlOverride = fetchLatestReleaseUrl,
+}) {
+  try {
+    const release = await fetchReleaseJson(`https://api.github.com/repos/${repo}/releases/latest`);
+    return getReleaseUpdateInfo(release, currentVersion, arch);
+  } catch (error) {
+    const releaseUrl = await fetchLatestReleaseUrlOverride(repo);
+    return getRedirectReleaseUpdateInfo(repo, releaseUrl, currentVersion, arch);
+  }
 }
 
 function safeDownloadName(name) {
@@ -143,6 +213,8 @@ module.exports = {
   checkForUpdates,
   compareVersions,
   downloadUpdateAsset,
+  fetchLatestReleaseUrl,
+  getRedirectReleaseUpdateInfo,
   getReleaseUpdateInfo,
   selectMacDmgAsset,
 };

--- a/src/__tests__/server/electron.test.ts
+++ b/src/__tests__/server/electron.test.ts
@@ -10,8 +10,16 @@ const { formatCost, formatTokens } = require('../../../electron/trayBadge.cjs') 
   formatCost: (cost: number) => string;
   formatTokens: (tokens: number) => string;
 };
-const { compareVersions, getReleaseUpdateInfo, selectMacDmgAsset } = require('../../../electron/updateService.cjs') as {
+const { checkForUpdates, compareVersions, getRedirectReleaseUpdateInfo, getReleaseUpdateInfo, selectMacDmgAsset } = require('../../../electron/updateService.cjs') as {
+  checkForUpdates: (options: {
+    repo: string;
+    currentVersion: string;
+    arch?: string;
+    fetchReleaseJson?: (url: string) => Promise<any>;
+    fetchLatestReleaseUrl?: (repo: string) => Promise<string>;
+  }) => Promise<any>;
   compareVersions: (a: string, b: string) => number;
+  getRedirectReleaseUpdateInfo: (repo: string, releaseUrl: string, currentVersion: string, arch?: string) => any;
   getReleaseUpdateInfo: (release: any, currentVersion: string, arch?: string) => any;
   selectMacDmgAsset: (assets: any[], arch?: string) => any;
 };
@@ -214,6 +222,47 @@ describe('updateService', () => {
       name: 'TokenDash-1.6.0-arm64.dmg',
       size: 123,
       url: 'https://example.com/TokenDash.dmg',
+    });
+  });
+
+  it('builds update info from the public latest-release redirect when the API is unavailable', () => {
+    const info = getRedirectReleaseUpdateInfo(
+      'zhangferry/tokendash',
+      'https://github.com/zhangferry/tokendash/releases/tag/v1.7.0',
+      '1.6.0',
+      'arm64',
+    );
+
+    expect(info).toEqual({
+      currentVersion: '1.6.0',
+      latestVersion: '1.7.0',
+      upToDate: false,
+      releaseUrl: 'https://github.com/zhangferry/tokendash/releases/tag/v1.7.0',
+      asset: {
+        name: 'TokenDash-1.7.0-arm64.dmg',
+        size: 0,
+        url: 'https://github.com/zhangferry/tokendash/releases/download/v1.7.0/TokenDash-1.7.0-arm64.dmg',
+      },
+    });
+  });
+
+  it('falls back to the public latest-release redirect when the GitHub API is rate-limited', async () => {
+    const info = await checkForUpdates({
+      repo: 'zhangferry/tokendash',
+      currentVersion: '1.6.0',
+      arch: 'arm64',
+      fetchReleaseJson: async () => {
+        throw new Error('HTTP 403');
+      },
+      fetchLatestReleaseUrl: async () => 'https://github.com/zhangferry/tokendash/releases/tag/v1.7.0',
+    });
+
+    expect(info.latestVersion).toBe('1.7.0');
+    expect(info.upToDate).toBe(false);
+    expect(info.error).toBeUndefined();
+    expect(info.asset).toMatchObject({
+      name: 'TokenDash-1.7.0-arm64.dmg',
+      url: 'https://github.com/zhangferry/tokendash/releases/download/v1.7.0/TokenDash-1.7.0-arm64.dmg',
     });
   });
 });


### PR DESCRIPTION
## Summary
- reproduce the menu-bar Check failure as GitHub's unauthenticated REST latest-release endpoint returning HTTP 403 rate-limit responses
- keep the existing REST API update check when available, but fall back to GitHub's public releases/latest redirect when the API cannot be reached
- derive the macOS DMG download URL from the fallback release tag so the settings Check button can still report/download updates

## Tests
- npx vitest run src/__tests__/server/electron.test.ts
- npm test
- npm run typecheck
- npm run build
- manual: node checkForUpdates while REST API was rate-limited returned v1.6.0 via the public releases/latest redirect