### PR TITLE
Restart the daemon automatically when it dies

### DIFF
--- a/TokenDashSwift/Sources/TokenDash/App.swift
+++ b/TokenDashSwift/Sources/TokenDash/App.swift
@@ -29,6 +29,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var daemonManager: DaemonManager?
     var badgeUpdater: BadgeUpdater?
     private var badgePollTimer: Timer?
+    private var daemonHealthTimer: Timer?
     private var outsideClickMonitor: Any?
     private var mainContentHeight: CGFloat = 620
 
@@ -83,6 +84,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        // Health monitor: if the daemon dies (crash, OOM kill, macOS sleep
+        // reclaim), restart it automatically so the popover never gets stuck
+        // on "Unable to fetch data". Cheap liveness check — no spawn if alive.
+        daemonHealthTimer = Timer.scheduledTimer(withTimeInterval: 30.0, repeats: true) { [weak self] _ in
+            self?.checkDaemonHealth()
+        }
+
         // Let AppKit finish installing the status item and panel before any
         // startup service work begins, so the very first click is responsive.
         DispatchQueue.main.async {
@@ -92,16 +100,51 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             UpdaterController.shared.start()
 
             Task { @MainActor in
-                do {
-                    NSLog("[TokenDash] Starting daemon...")
-                    let port = try await manager.startDaemon()
-                    NSLog("[TokenDash] Daemon ready on port \(port)")
-                    updater.start(port: port)
-                    NSLog("[TokenDash] BadgeUpdater started")
-                } catch {
-                    NSLog("[TokenDash] Failed to start daemon: \(error.localizedDescription)")
-                    self.state.errorMessage = error.localizedDescription
+                await self.startDaemonWithRetry()
+            }
+        }
+    }
+
+    /// Spawn (or reattach to) the daemon with a few retries. If every attempt
+    /// fails, the 30s health monitor keeps trying in the background.
+    @MainActor private func startDaemonWithRetry(maxAttempts: Int = 3) async {
+        guard let manager = daemonManager else { return }
+        for attempt in 1...maxAttempts {
+            do {
+                NSLog("[TokenDash] Starting daemon (attempt \(attempt)/\(maxAttempts))...")
+                let port = try await manager.startDaemon()
+                NSLog("[TokenDash] Daemon ready on port \(port)")
+                badgeUpdater?.start(port: port)
+                NSLog("[TokenDash] BadgeUpdater started")
+                return
+            } catch {
+                NSLog("[TokenDash] Daemon start attempt \(attempt) failed: \(error.localizedDescription)")
+                state.isDaemonReady = false
+                if attempt < maxAttempts {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                } else {
+                    state.errorMessage = error.localizedDescription
                 }
+            }
+        }
+    }
+
+    /// Periodic liveness check. Restarts the daemon if it has died and
+    /// hot-switches the BadgeUpdater to the new port so the popover recovers
+    /// without an app restart.
+    func checkDaemonHealth() {
+        guard let manager = daemonManager else { return }
+        if manager.isAlive() { return }
+        NSLog("[TokenDash] Health check: daemon not alive — restarting")
+        state.isDaemonReady = false
+        Task { @MainActor in
+            do {
+                let port = try await manager.startDaemon()
+                badgeUpdater?.updatePort(port)
+                NSLog("[TokenDash] Daemon restarted on port \(port)")
+            } catch {
+                NSLog("[TokenDash] Daemon restart failed: \(error.localizedDescription)")
+                state.errorMessage = error.localizedDescription
             }
         }
     }
@@ -109,6 +152,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         stopOutsideClickMonitor()
         badgePollTimer?.invalidate()
+        daemonHealthTimer?.invalidate()
         badgeUpdater?.stop()
         daemonManager?.stopDaemon()
     }

--- a/TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift
+++ b/TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift
@@ -17,10 +17,30 @@ import AppKit
     }
 
     func start(port: Int) {
+        applyPort(port)
+        ensureTimer()
+        update()
+    }
+
+    /// Hot-switch to a new daemon port after the daemon has been restarted,
+    /// without tearing down the polling timer. Clears any stale error so the
+    /// popover recovers immediately once the daemon is back.
+    func updatePort(_ port: Int) {
+        applyPort(port)
+        ensureTimer()
+        NSLog("[TokenDash] BadgeUpdater switched to port \(port)")
+        update()
+    }
+
+    private func applyPort(_ port: Int) {
         self.apiClient = APIClient(port: port)
         self.state.daemonPort = port
         self.state.isDaemonReady = true
-        update()
+        self.state.errorMessage = nil
+    }
+
+    private func ensureTimer() {
+        guard timer == nil else { return }
         timer = Timer.scheduledTimer(withTimeInterval: tickInterval, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.tick() }
         }

--- a/TokenDashSwift/Sources/TokenDash/DaemonManager.swift
+++ b/TokenDashSwift/Sources/TokenDash/DaemonManager.swift
@@ -77,6 +77,15 @@ import Foundation
         throw DaemonError.timeout
     }
 
+    /// Quick liveness probe — true if the daemon we spawned is still running
+    /// or a PID file points at a live process. Used by AppDelegate's health
+    /// monitor to decide whether a restart is needed. Cheap (no network call).
+    func isAlive() -> Bool {
+        if let proc = process, proc.isRunning { return true }
+        if let pid = readPidFile(), isProcessAlive(pid: pid) { return true }
+        return false
+    }
+
     func stopDaemon() {
         if let pid = readPidFile() {
             stopDaemonProcess(pid: pid)

--- a/TokenDashSwift/Sources/TokenDash/Views/ActionButtons.swift
+++ b/TokenDashSwift/Sources/TokenDash/Views/ActionButtons.swift
@@ -8,9 +8,8 @@ struct ActionButtons: View {
     var body: some View {
         HStack(spacing: 0) {
             Button {
-                if let url = URL(string: "http://localhost:\(state.daemonPort)") {
-                    NSWorkspace.shared.open(url)
-                }
+                guard state.isDaemonReady, let url = URL(string: "http://localhost:\(state.daemonPort)") else { return }
+                NSWorkspace.shared.open(url)
             } label: {
                 Label("Dashboard", systemImage: "chart.bar")
                     .font(.system(size: 11, weight: .medium))
@@ -20,6 +19,8 @@ struct ActionButtons: View {
                     .background(isDashboardHovered ? Color.primary.opacity(0.04) : Color.clear)
             }
             .buttonStyle(.plain)
+            .disabled(!state.isDaemonReady)
+            .help(state.isDaemonReady ? "Open web dashboard" : "Starting service…")
             .onHover { hovering in isDashboardHovered = hovering }
 
             Rectangle()


### PR DESCRIPTION
## Problem
The menu-bar popover only spawned the Node daemon **once at launch** (`App.swift`): no retry on failure, no liveness monitoring. So if the daemon ever exited — crash, OOM kill, macOS sleep reclaim, or a startup timeout — the popover stayed stuck on **"Unable to fetch data. Retrying..."** and the **Dashboard** button opened a dead `localhost` URL until the app was restarted by hand.

## Fix
Give the daemon three layers of self-healing:
- **Startup retry** — `startDaemonWithRetry` tries up to 3 times (2s apart) before giving up.
- **Health monitor** — a 30s timer calls `checkDaemonHealth()`; if `DaemonManager.isAlive()` is false it restarts the daemon and hot-swaps `BadgeUpdater` to the new port via the new `updatePort(_:)`.
- **Ready gating** — the Dashboard button is disabled until `state.isDaemonReady`, so it never opens a dead URL.

### Files
- `DaemonManager.swift` — `isAlive()` liveness check (process.isRunning or live PID).
- `App.swift` — startup retry + 30s `daemonHealthTimer` + `checkDaemonHealth()` + cleanup on terminate.
- `BadgeUpdater.swift` — `updatePort(_:)` hot-swap + extracted `applyPort`/`ensureTimer`.
- `ActionButtons.swift` — disable Dashboard until the daemon is ready.

## Verification
- `swift build -c release` clean.
- Replaced binary + ad-hoc re-signed, app launches normally.
- `kill -9` on the daemon (PID 7337) → auto-restarted within ~35s (new PID 8192, port 3456); `/api/agents` and `/api/daily` return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)