### PR TITLE
TokenDash v1.8.0 — energy optimization + reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### v1.8.0
+- **Lower menu-bar energy use** — drive the badge/popover refresh from a dormant/active/suspended state machine instead of a fixed 5s poll, so popover-closed CPU drops to ~0 while keeping full-speed refresh when the popover is open. System sleep and low-power mode pause polling entirely.
+- **No more orphan daemons** — the node daemon now watches its parent app and exits when the app dies (crash, force-quit, `pkill`), and the health check no longer restarts during daemon warm-up. This fixes the duplicate daemons that stacked across ports over time and starved the popover of data.
+- **Popover never opens empty** — prime detail state on launch, paint today/hourly/projects before the slower quota fetch, and fall back to the previous view (stale-while-revalidate) when today data is not ready yet.
+- **Pulse tab hidden (temporary)** — the experimental real-time rate chart and its 10s sampler are gated off while energy impact is being tightened; the code stays in place for a later return.
+
 ### v1.7.5
 - **Reliable menu bar refreshes** — make the native app's refresh interval bypass server-side usage and Coding Plan caches so new data appears on the schedule selected in Settings.
 - **Smoother Coding Plan fallback** — keep showing the last successful quota snapshot when an upstream provider returns a transient error or empty response, avoiding stale/error flashes after data has already loaded.

--- a/TokenDashSwift/Package.swift
+++ b/TokenDashSwift/Package.swift
@@ -15,5 +15,10 @@ let package = Package(
             ],
             path: "Sources/TokenDash"
         ),
+        .testTarget(
+            name: "TokenDashTests",
+            dependencies: ["TokenDash"],
+            path: "Tests/TokenDashTests"
+        ),
     ]
 )

--- a/TokenDashSwift/Sources/TokenDash/App.swift
+++ b/TokenDashSwift/Sources/TokenDash/App.swift
@@ -144,11 +144,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// hot-switches the BadgeUpdater to the new port so the popover recovers
     /// without an app restart.
     func checkDaemonHealth() {
-        guard let manager = daemonManager else { return }
-        if manager.isAlive() { return }
-        NSLog("[TokenDash] Health check: daemon not alive — restarting")
-        state.isDaemonReady = false
+        guard daemonManager != nil else { return }
         Task { @MainActor in
+            guard let manager = daemonManager else { return }
+            // Port probe is authoritative across reattach (where DaemonManager
+            // has no Process handle and pid-file state may lag). Avoids spurious
+            // restarts that spawn duplicate daemons.
+            if await manager.isAliveViaProbe() { return }
+            NSLog("[TokenDash] Health check: daemon not responding — restarting")
+            state.isDaemonReady = false
             do {
                 let port = try await manager.startDaemon()
                 badgeUpdater?.updatePort(port)

--- a/TokenDashSwift/Sources/TokenDash/App.swift
+++ b/TokenDashSwift/Sources/TokenDash/App.swift
@@ -91,6 +91,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.checkDaemonHealth()
         }
 
+        // Power awareness: suspend the refresh state machine on sleep / low power
+        // so the menu bar stops polling entirely while the system is idle.
+        let ws = NSWorkspace.shared.notificationCenter
+        ws.addObserver(self, selector: #selector(systemWillSleep),
+                       name: NSWorkspace.willSleepNotification, object: nil)
+        ws.addObserver(self, selector: #selector(systemDidWake),
+                       name: NSWorkspace.didWakeNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(powerStateChanged),
+            name: Notification.Name.NSProcessInfoPowerStateDidChange, object: nil)
+
         // Let AppKit finish installing the status item and panel before any
         // startup service work begins, so the very first click is responsive.
         DispatchQueue.main.async {
@@ -149,6 +160,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    // MARK: - Power state → refresh mode
+
+    @objc private func systemWillSleep() {
+        setBadgeMode(.suspended)
+    }
+
+    @objc private func systemDidWake() {
+        // Wake up with popover hidden → dormant. (If the popover was open when
+        // sleeping, the user will click again and togglePopover flips to active.)
+        setBadgeMode(.dormant)
+    }
+
+    @objc private func powerStateChanged() {
+        if ProcessInfo.processInfo.isLowPowerModeEnabled {
+            setBadgeMode(.suspended)
+        }
+        // Exiting low-power mode does not auto-resume; the next popover toggle
+        // or sleep/wake cycle restarts the appropriate mode.
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         stopOutsideClickMonitor()
         badgePollTimer?.invalidate()
@@ -158,6 +189,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     // MARK: - Panel toggle
+
+    /// Bridges a nonisolated AppKit/selector context to the @MainActor
+    /// BadgeUpdater.setMode. AppKit invokes togglePopover/hidePopover and the
+    /// power-state @objc callbacks off the actor, so hop onto MainActor here.
+    private func setBadgeMode(_ mode: BadgeUpdater.RefreshMode) {
+        Task { @MainActor in badgeUpdater?.setMode(mode) }
+    }
 
     @objc private func togglePopover() {
         if panel.isVisible {
@@ -186,12 +224,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             panel.orderFrontRegardless()
             panel.makeKey()
             startOutsideClickMonitor()
+            setBadgeMode(.active)
         }
     }
 
     private func hidePopover() {
         panel.orderOut(nil)
         stopOutsideClickMonitor()
+        setBadgeMode(.dormant)
     }
 
     private func startOutsideClickMonitor() {

--- a/TokenDashSwift/Sources/TokenDash/App.swift
+++ b/TokenDashSwift/Sources/TokenDash/App.swift
@@ -147,9 +147,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard daemonManager != nil else { return }
         Task { @MainActor in
             guard let manager = daemonManager else { return }
-            // Port probe is authoritative across reattach (where DaemonManager
-            // has no Process handle and pid-file state may lag). Avoids spurious
-            // restarts that spawn duplicate daemons.
+            // Trust a live process handle / pid-file FIRST. A port-probe timeout
+            // during daemon warm-up (JSONL parsing blocks the Node event loop) is
+            // NOT a death signal — probing in that window spawned duplicate
+            // daemons on the health-check cadence (8 ghosts across 3456-3463),
+            // each one switching the app onto a still-warming daemon with empty
+            // caches (the empty-popover bug). Only probe + restart when the
+            // process is actually gone.
+            if manager.isAlive() { return }
             if await manager.isAliveViaProbe() { return }
             NSLog("[TokenDash] Health check: daemon not responding — restarting")
             state.isDaemonReady = false

--- a/TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift
+++ b/TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift
@@ -3,33 +3,58 @@ import AppKit
 
 /// Periodically fetches usage data from the API, updates the menu bar badge image
 /// and refreshes the shared AppState for the popover.
+///
+/// Refresh is driven by a three-state machine (`RefreshMode`) instead of a fixed
+/// high-frequency timer:
+/// - `.dormant`  — popover closed: only the cheap badge update (today total),
+///                 served from the daemon cache. No pulse, no details, no quota.
+/// - `.active`   — popover open: immediate full refresh + 10s pulse (refresh,
+///                 for rate deltas) + 60s cached detail refresh.
+/// - `.suspended`— system sleep / low power: all data timers stopped.
 @MainActor class BadgeUpdater {
     private let state: AppState
-    private var apiClient: APIClient?
-    private var timer: Timer?
-    /// Heartbeat cadence (cheap — just checks the clock). Actual fetch cadence
-    /// follows SettingsStore.refreshInterval.
-    private let tickInterval: TimeInterval = 5.0
-    private var lastUpdate: Date = .distantPast
+    private var apiClient: (any APIClientProtocol)?
 
-    init(state: AppState) {
+    enum RefreshMode { case dormant, active, suspended }
+    private(set) var mode: RefreshMode = .dormant
+
+    // Cadences (seconds). dormant reuses the user's SettingsStore.refreshInterval
+    // (it is cache-served, so even 30s stays cheap). active cadences are fixed.
+    private var dormantInterval: TimeInterval { SettingsStore.shared.refreshInterval.rawValue }
+    private let activePulseInterval: TimeInterval = 10.0
+    private let activeFullInterval: TimeInterval = 60.0
+
+    private var dormantTimer: Timer?
+    private var pulseTimer: Timer?
+    private var fullTimer: Timer?
+
+    private var activeAgents: [String] = []
+    private var isPulseSampling = false
+    private var lastPulseObservation: (
+        date: String,
+        timestamp: Date,
+        totalTokens: Int,
+        inputTokens: Int,
+        outputTokens: Int
+    )?
+
+    init(state: AppState, client: (any APIClientProtocol)? = nil) {
         self.state = state
+        self.apiClient = client
     }
 
     func start(port: Int) {
         applyPort(port)
-        ensureTimer()
-        update()
+        setMode(.dormant)   // app launches with popover hidden
     }
 
-    /// Hot-switch to a new daemon port after the daemon has been restarted,
-    /// without tearing down the polling timer. Clears any stale error so the
-    /// popover recovers immediately once the daemon is back.
+    /// Hot-switch to a new daemon port after restart, preserving the current mode.
     func updatePort(_ port: Int) {
+        let resumeMode = mode
         applyPort(port)
-        ensureTimer()
         NSLog("[TokenDash] BadgeUpdater switched to port \(port)")
-        update()
+        mode = .suspended     // force setMode to rebuild timers against new port
+        setMode(resumeMode)
     }
 
     private func applyPort(_ port: Int) {
@@ -39,151 +64,272 @@ import AppKit
         self.state.errorMessage = nil
     }
 
-    private func ensureTimer() {
-        guard timer == nil else { return }
-        timer = Timer.scheduledTimer(withTimeInterval: tickInterval, repeats: true) { [weak self] _ in
-            Task { @MainActor in self?.tick() }
+    // MARK: - Mode state machine
+
+    func setMode(_ newMode: RefreshMode) {
+        mode = newMode
+        stopDataTimers()
+        switch newMode {
+        case .dormant:
+            scheduleDormant()
+            Task { await self.performBadgeUpdate() }   // immediate refresh on entry
+        case .active:
+            Task { await self.performFullUpdate(forceRefresh: true, forceQuota: false) }
+            schedulePulse()
+            scheduleActiveFull()
+        case .suspended:
+            break   // all data timers stopped; daemon healthCheck (AppDelegate) keeps running
         }
+        NSLog("[TokenDash] BadgeUpdater mode → \(newMode)")
+    }
+
+    private func scheduleDormant() {
+        let t = Timer(timeInterval: dormantInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in await self?.performBadgeUpdate() }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        dormantTimer = t
+    }
+
+    private func schedulePulse() {
+        let t = Timer(timeInterval: activePulseInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.samplePulse() }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        pulseTimer = t
+    }
+
+    private func scheduleActiveFull() {
+        let t = Timer(timeInterval: activeFullInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in await self?.performFullUpdate(forceRefresh: false, forceQuota: false) }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        fullTimer = t
+    }
+
+    private func stopDataTimers() {
+        dormantTimer?.invalidate(); dormantTimer = nil
+        pulseTimer?.invalidate(); pulseTimer = nil
+        fullTimer?.invalidate(); fullTimer = nil
     }
 
     func stop() {
-        timer?.invalidate()
-        timer = nil
+        stopDataTimers()
     }
 
-    /// Trigger an immediate refresh (e.g. from the refresh button).
+    /// Manual refresh (refresh button) — force everything, including external quota.
     func refreshNow() {
-        update()
+        Task { await self.performFullUpdate(forceRefresh: true, forceQuota: true) }
     }
 
-    private func tick() {
-        let interval = SettingsStore.shared.refreshInterval
-        if Date().timeIntervalSince(lastUpdate) >= interval.rawValue {
-            update()
+    // MARK: - dormant: cheap badge update (cache-served)
+
+    /// Updates only today's total tokens + cost for the menu bar badge. Served
+    /// from the daemon's 5min cache (refresh:false) so it never triggers JSONL
+    /// re-parsing. Does not touch detail state (hourly/projects/trend/quota).
+    func performBadgeUpdate() async {
+        guard let api = apiClient else { return }
+        do {
+            let agentsResp = try await api.getAgents()
+            let agents = agentsResp.available.isEmpty ? ["claude"] : agentsResp.available
+            self.activeAgents = agents
+
+            let today = todayString()
+            var totalTokens = 0
+            var totalCost = 0.0
+            for agent in agents {
+                if let d = try? await api.getDaily(agent: agent, refresh: false) {
+                    if let entry = d.daily.first(where: { $0.date == today }) {
+                        totalTokens += entry.totalTokens
+                        totalCost += entry.totalCost
+                    }
+                }
+            }
+
+            let tokenStr = formatTokens(totalTokens)
+            self.state.badgeImage = Self.renderBadgeImage(title: tokenStr)
+            self.state.tooltipText = String(
+                format: "TokenDash - %@ tokens today ($%.2f)", tokenStr, totalCost)
+            self.state.isLoading = false
+            self.state.errorMessage = nil
+        } catch {
+            NSLog("[TokenDash] badge update error: \(error.localizedDescription)")
+            self.state.errorMessage = error.localizedDescription
         }
     }
 
-    // MARK: - Update cycle
+    // MARK: - active: full popover refresh
 
-    private func update() {
+    /// Full refresh for the open popover: daily + blocks + projects + quota +
+    /// derived hourly/projects/models/trend. `forceRefresh` bypasses the daemon
+    /// usage cache (used on popover open); `forceQuota` bypasses the 60s quota
+    /// cache (manual refresh only).
+    func performFullUpdate(forceRefresh: Bool, forceQuota: Bool) async {
         guard let api = apiClient else {
-            NSLog("[TokenDash] update() called but apiClient is nil")
+            NSLog("[TokenDash] performFullUpdate called but apiClient is nil")
             return
         }
-        lastUpdate = Date()
-        let port = state.daemonPort
-        // Use a regular Task (inherits MainActor) instead of Task.detached
-        // This ensures state updates trigger SwiftUI observation correctly.
-        Task { [weak self] in
-            guard let self = self else { return }
+        do {
+            let agentsResp = try await api.getAgents()
+            let agents = agentsResp.available.isEmpty ? ["claude"] : agentsResp.available
+            self.activeAgents = agents
+
+            var dailyResults: [DailyResponse] = []
+            var blockResults: [BlocksResponse] = []
+            var projectResults: [ProjectsResponse] = []
+
+            for agent in agents {
+                if let d = try? await api.getDaily(agent: agent, refresh: forceRefresh) { dailyResults.append(d) }
+                // Detail endpoints always cache-served (refresh:false) — daemon reuses its
+                // 5min cache, so the 60s active cadence does NOT re-parse JSONL.
+                if let b = try? await api.getBlocks(agent: agent, refresh: false) { blockResults.append(b) }
+                if let p = try? await api.getProjects(agent: agent, refresh: false) { projectResults.append(p) }
+            }
+
+            let today = todayString()
+            var totalTokens = 0, totalInput = 0, totalOutput = 0, totalCacheRead = 0
+            var totalCost = 0.0
+            for data in dailyResults {
+                guard let entry = data.daily.first(where: { $0.date == today }) else { continue }
+                totalTokens += entry.totalTokens
+                totalInput += entry.inputTokens
+                totalOutput += entry.outputTokens
+                totalCacheRead += entry.cacheReadTokens
+                totalCost += entry.totalCost
+            }
+            let denom = Double(totalInput + totalCacheRead)
+            let cacheRate = denom > 0 ? Double(totalCacheRead) / denom * 100 : 0
+            let tokenStr = formatTokens(totalTokens)
+            let badgeImage = Self.renderBadgeImage(title: tokenStr)
+            let summary = TodaySummary(
+                tokens: totalTokens, cost: totalCost,
+                inputTokens: totalInput, outputTokens: totalOutput,
+                cacheReadTokens: totalCacheRead, cacheRate: cacheRate)
+            if dailyResults.count == agents.count {
+                self.recordPulseObservation(
+                    totalTokens: totalTokens, inputTokens: totalInput, outputTokens: totalOutput,
+                    date: today, at: Date())
+            }
+            let hourly = computeHourly(blocks: blockResults, today: today)
+            let projectRows = computeProjects(projects: projectResults, today: today)
+            let modelRows = computeModels(daily: dailyResults, today: today)
+            let trendPoints = computeTrend(daily: dailyResults)
+
+            // Coding Plan quotas — cache-served unless this is a manual refresh.
+            var quotaSnapshots = self.state.quotas
             do {
-                NSLog("[TokenDash] Fetching agents from port \(port)...")
-                let agentsResp = try await api.getAgents()
-                let agents = agentsResp.available.isEmpty ? ["claude"] : agentsResp.available
-                NSLog("[TokenDash] Agents: \(agents)")
-
-                NSLog("[TokenDash] Fetching daily/blocks/projects for \(agents.count) agents...")
-
-                var dailyResults: [DailyResponse] = []
-                var blockResults: [BlocksResponse] = []
-                var projectResults: [ProjectsResponse] = []
-
-                for agent in agents {
-                    NSLog("[TokenDash] Fetching daily for \(agent)...")
-                    do {
-                        let d = try await api.getDaily(agent: agent, refresh: true)
-                        dailyResults.append(d)
-                        NSLog("[TokenDash] Got daily for \(agent): \(d.daily.count) days")
-                    } catch {
-                        NSLog("[TokenDash] FAILED daily for \(agent): \(error)")
-                    }
-                    do {
-                        let b = try await api.getBlocks(agent: agent, refresh: true)
-                        blockResults.append(b)
-                    } catch {
-                        NSLog("[TokenDash] FAILED blocks for \(agent): \(error)")
-                    }
-                    do {
-                        let p = try await api.getProjects(agent: agent, refresh: true)
-                        projectResults.append(p)
-                    } catch {
-                        NSLog("[TokenDash] FAILED projects for \(agent): \(error)")
-                    }
-                }
-                NSLog("[TokenDash] Got \(dailyResults.count) daily, \(blockResults.count) blocks, \(projectResults.count) projects")
-
-                // Compute summary
-                let today = todayString()
-                var totalTokens = 0, totalInput = 0, totalOutput = 0, totalCacheRead = 0
-                var totalCost = 0.0
-
-                for data in dailyResults {
-                    guard let entry = data.daily.first(where: { $0.date == today }) else { continue }
-                    totalTokens += entry.totalTokens
-                    totalInput += entry.inputTokens
-                    totalOutput += entry.outputTokens
-                    totalCacheRead += entry.cacheReadTokens
-                    totalCost += entry.totalCost
-                }
-
-                let denom = Double(totalInput + totalCacheRead)
-                let cacheRate = denom > 0 ? Double(totalCacheRead) / denom * 100 : 0
-
-                let tokenStr = formatTokens(totalTokens)
-                let tooltip = String(format: "TokenDash - %@ tokens today ($%.2f) | cache: %.1f%%", tokenStr, totalCost, cacheRate)
-                let badgeImage = Self.renderBadgeImage(title: tokenStr)
-                let summary = TodaySummary(
-                    tokens: totalTokens, cost: totalCost,
-                    inputTokens: totalInput, outputTokens: totalOutput,
-                    cacheReadTokens: totalCacheRead, cacheRate: cacheRate
-                )
-                let hourly = computeHourly(blocks: blockResults, today: today)
-                let projectRows = computeProjects(projects: projectResults, today: today)
-                let modelRows = computeModels(daily: dailyResults, today: today)
-                let trendPoints = computeTrend(daily: dailyResults)
-
-                NSLog("[TokenDash] Today: \(tokenStr) tokens, \(formatCost(totalCost)), cache \(formatPercent(cacheRate))")
-
-                // Coding Plan quotas — independent of the daily usage fetch above.
-                // Failures are isolated per-provider by the server, so a missing
-                // credential never breaks the rest of the popover.
-                var quotaSnapshots = self.state.quotas
-                do {
-                    let quotaResp = try await api.getQuota(refresh: true)
-                    quotaSnapshots = self.retainUsableQuotas(quotaResp.providers, previous: self.state.quotas)
-                    NSLog("[TokenDash] Quota: \(quotaSnapshots.count) providers")
-                } catch {
-                    NSLog("[TokenDash] Quota fetch failed (non-fatal): \(error)")
-                }
-
-                // Direct state update — we're on MainActor, observation will fire
-                self.state.badgeImage = badgeImage
-                self.state.tooltipText = tooltip
-                self.state.todaySummary = summary
-                self.state.cacheRate = cacheRate
-                self.state.isLoading = false
-                self.state.errorMessage = nil
-                self.state.hourlyData = hourly
-                self.state.projects = projectRows
-                self.state.models = modelRows
-                self.state.trend = trendPoints
-                self.state.quotas = quotaSnapshots
-
-                // Low-quota notifications (no-op if disabled in settings).
-                NotificationService.shared.evaluate(quotas: quotaSnapshots)
-
+                let quotaResp = try await api.getQuota(refresh: forceQuota)
+                quotaSnapshots = self.retainUsableQuotas(quotaResp.providers, previous: self.state.quotas)
             } catch {
-                NSLog("[TokenDash] update() error: \(error.localizedDescription)")
-                self.state.errorMessage = error.localizedDescription
+                NSLog("[TokenDash] Quota fetch failed (non-fatal): \(error)")
+            }
+
+            self.state.badgeImage = badgeImage
+            self.state.tooltipText = String(
+                format: "TokenDash - %@ tokens today ($%.2f) | cache: %.1f%%",
+                tokenStr, totalCost, cacheRate)
+            self.state.todaySummary = summary
+            self.state.cacheRate = cacheRate
+            self.state.isLoading = false
+            self.state.errorMessage = nil
+            self.state.hourlyData = hourly
+            self.state.projects = projectRows
+            self.state.models = modelRows
+            self.state.trend = trendPoints
+            self.state.quotas = quotaSnapshots
+
+            NotificationService.shared.evaluate(quotas: quotaSnapshots)
+        } catch {
+            NSLog("[TokenDash] full update error: \(error.localizedDescription)")
+            self.state.errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Pulse sampling (active only)
+
+    /// Samples today's cumulative token count every activePulseInterval. refresh:true
+    /// because rate deltas need fresh totals (a cache-served value would freeze the
+    /// rate chart at zero). Only scheduled in `.active`.
+    private func samplePulse() {
+        guard let api = apiClient, !isPulseSampling else { return }
+        isPulseSampling = true
+        Task { [weak self] in
+            guard let self else { return }
+            defer { self.isPulseSampling = false }
+            do {
+                let agents: [String]
+                if self.activeAgents.isEmpty {
+                    let resp = try await api.getAgents()
+                    agents = resp.available.isEmpty ? ["claude"] : resp.available
+                } else {
+                    agents = self.activeAgents
+                }
+                let today = todayString()
+                var totalTokens = 0, inputTokens = 0, outputTokens = 0, ok = 0
+                for agent in agents {
+                    do {
+                        let r = try await api.getDaily(agent: agent, refresh: true)
+                        if let e = r.daily.first(where: { $0.date == today }) {
+                            totalTokens += e.totalTokens
+                            inputTokens += e.inputTokens
+                            outputTokens += e.outputTokens
+                        }
+                        ok += 1
+                    } catch {
+                        NSLog("[TokenDash] Pulse sample failed for \(agent): \(error)")
+                    }
+                }
+                guard ok == agents.count else { return }
+                self.recordPulseObservation(
+                    totalTokens: totalTokens, inputTokens: inputTokens, outputTokens: outputTokens,
+                    date: today, at: Date())
+            } catch {
+                NSLog("[TokenDash] Pulse sampling failed: \(error)")
             }
         }
+    }
+
+    private func recordPulseObservation(
+        totalTokens: Int, inputTokens: Int, outputTokens: Int, date: String, at timestamp: Date
+    ) {
+        guard let previous = lastPulseObservation, previous.date == date else {
+            lastPulseObservation = (date, timestamp, totalTokens, inputTokens, outputTokens)
+            if let latest = state.pulseSamples.last,
+               !Calendar.current.isDate(latest.timestamp, inSameDayAs: timestamp) {
+                state.pulseSamples = []
+                TokenPulseHistoryStore.shared.save([], now: timestamp)
+            }
+            return
+        }
+        let elapsed = timestamp.timeIntervalSince(previous.timestamp)
+        guard elapsed > 0 else { return }
+        // A lower total means the source was reset or reparsed. Reset the
+        // baseline instead of drawing a false negative spike.
+        let delta = totalTokens >= previous.totalTokens ? totalTokens - previous.totalTokens : 0
+        let inputDelta = inputTokens >= previous.inputTokens ? inputTokens - previous.inputTokens : 0
+        let outputDelta = outputTokens >= previous.outputTokens ? outputTokens - previous.outputTokens : 0
+        let sample = TokenPulseSample(
+            timestamp: timestamp,
+            tokenDelta: delta,
+            tokensPerSecond: Double(delta) / elapsed,
+            inputDelta: inputDelta,
+            outputDelta: outputDelta,
+            inputTokensPerSecond: Double(inputDelta) / elapsed,
+            outputTokensPerSecond: Double(outputDelta) / elapsed
+        )
+        let cutoff = timestamp.addingTimeInterval(-30 * 60)
+        state.pulseSamples = (state.pulseSamples + [sample])
+            .filter { $0.timestamp >= cutoff }
+            .suffix(360)
+            .map { $0 }
+        TokenPulseHistoryStore.shared.save(state.pulseSamples, now: timestamp)
+        lastPulseObservation = (date, timestamp, totalTokens, inputTokens, outputTokens)
     }
 
     private func retainUsableQuotas(_ incoming: [QuotaSnapshot], previous: [QuotaSnapshot]) -> [QuotaSnapshot] {
         guard !incoming.isEmpty else { return previous }
         let previousByProvider = Dictionary(uniqueKeysWithValues: previous.map { ($0.provider, $0) })
         var retainedProviders = Set<String>()
-
         var merged = incoming.compactMap { snapshot -> QuotaSnapshot? in
             retainedProviders.insert(snapshot.provider)
             if snapshot.status.state == "ok", snapshot.freshness != "stale", !snapshot.windows.isEmpty {
@@ -191,7 +337,6 @@ import AppKit
             }
             return previousByProvider[snapshot.provider]
         }
-
         for snapshot in previous where !retainedProviders.contains(snapshot.provider) {
             merged.append(snapshot)
         }

--- a/TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift
+++ b/TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift
@@ -79,10 +79,11 @@ import AppKit
             scheduleDormant()
             Task { await self.performBadgeUpdate() }   // immediate refresh on entry
         case .active:
-            // Cache-served open (warm-up pre-filled daily/blocks/projects) so the
-            // popover paints instantly. The 60s active detail timer + manual
-            // refresh keep it fresh; we don't bypass the cache on every open.
-            Task { await self.performFullUpdate(forceRefresh: false, forceQuota: false) }
+            // Force-refresh on open so the user sees the latest today data, not a
+            // possibly-stale cache. The 60s active detail timer + manual refresh
+            // keep it fresh afterwards; only this open moment bypasses the cache.
+            Task { await self.performFullUpdate(forceRefresh: true, forceQuota: false) }
+            samplePulse()  // prime a pulse baseline immediately, don't wait 10s
             schedulePulse()
             scheduleActiveFull()
         case .suspended:
@@ -187,11 +188,11 @@ import AppKit
             var projectResults: [ProjectsResponse] = []
 
             for agent in agents {
+                // On open (forceRefresh=true) bypass cache for fresh today data;
+                // the 60s active timer passes forceRefresh=false to reuse the cache.
                 if let d = try? await api.getDaily(agent: agent, refresh: forceRefresh) { dailyResults.append(d) }
-                // Detail endpoints always cache-served (refresh:false) — daemon reuses its
-                // 5min cache, so the 60s active cadence does NOT re-parse JSONL.
-                if let b = try? await api.getBlocks(agent: agent, refresh: false) { blockResults.append(b) }
-                if let p = try? await api.getProjects(agent: agent, refresh: false) { projectResults.append(p) }
+                if let b = try? await api.getBlocks(agent: agent, refresh: forceRefresh) { blockResults.append(b) }
+                if let p = try? await api.getProjects(agent: agent, refresh: forceRefresh) { projectResults.append(p) }
             }
 
             let today = todayString()
@@ -218,8 +219,16 @@ import AppKit
                     totalTokens: totalTokens, inputTokens: totalInput, outputTokens: totalOutput,
                     date: today, at: Date())
             }
-            let hourly = computeHourly(blocks: blockResults, today: today)
-            let projectRows = computeProjects(projects: projectResults, today: today)
+            let computedHourly = computeHourly(blocks: blockResults, today: today)
+            let computedProjects = computeProjects(projects: projectResults, today: today)
+            // Stale-while-revalidate fallback: if this fetch came back without
+            // today data (e.g. daemon warm-up still running), keep the previous
+            // view rather than show an empty chart. The next refresh replaces it.
+            let hourly = (computedHourly.allSatisfy { $0.tokens == 0 }
+                          && state.hourlyData.contains { $0.tokens > 0 })
+                ? state.hourlyData : computedHourly
+            let projectRows = (computedProjects.isEmpty && !state.projects.isEmpty)
+                ? state.projects : computedProjects
             let modelRows = computeModels(daily: dailyResults, today: today)
             let trendPoints = computeTrend(daily: dailyResults)
 

--- a/TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift
+++ b/TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift
@@ -45,6 +45,11 @@ import AppKit
 
     func start(port: Int) {
         applyPort(port)
+        // Prime detail state once on launch so the first popover open isn't
+        // empty — dormant mode afterwards only refreshes the badge. All
+        // cache-served (warm-up has filled daily/blocks/projects), and quota
+        // runs async so it never blocks this initial paint.
+        Task { await self.performFullUpdate(forceRefresh: false, forceQuota: false) }
         setMode(.dormant)   // app launches with popover hidden
     }
 
@@ -74,7 +79,10 @@ import AppKit
             scheduleDormant()
             Task { await self.performBadgeUpdate() }   // immediate refresh on entry
         case .active:
-            Task { await self.performFullUpdate(forceRefresh: true, forceQuota: false) }
+            // Cache-served open (warm-up pre-filled daily/blocks/projects) so the
+            // popover paints instantly. The 60s active detail timer + manual
+            // refresh keep it fresh; we don't bypass the cache on every open.
+            Task { await self.performFullUpdate(forceRefresh: false, forceQuota: false) }
             schedulePulse()
             scheduleActiveFull()
         case .suspended:
@@ -215,15 +223,8 @@ import AppKit
             let modelRows = computeModels(daily: dailyResults, today: today)
             let trendPoints = computeTrend(daily: dailyResults)
 
-            // Coding Plan quotas — cache-served unless this is a manual refresh.
-            var quotaSnapshots = self.state.quotas
-            do {
-                let quotaResp = try await api.getQuota(refresh: forceQuota)
-                quotaSnapshots = self.retainUsableQuotas(quotaResp.providers, previous: self.state.quotas)
-            } catch {
-                NSLog("[TokenDash] Quota fetch failed (non-fatal): \(error)")
-            }
-
+            // Detail state (cache-served, instant) — painted BEFORE quota so the
+            // popover isn't blocked on upstream quota calls (which can take 1-2s).
             self.state.badgeImage = badgeImage
             self.state.tooltipText = String(
                 format: "TokenDash - %@ tokens today ($%.2f) | cache: %.1f%%",
@@ -236,12 +237,33 @@ import AppKit
             self.state.projects = projectRows
             self.state.models = modelRows
             self.state.trend = trendPoints
-            self.state.quotas = quotaSnapshots
 
-            NotificationService.shared.evaluate(quotas: quotaSnapshots)
+            // Quota refreshes async (upstream calls can take 1-2s); don't block
+            // the detail paint. A manual refresh (forceQuota) still awaits so the
+            // user sees the result of their explicit refresh.
+            if forceQuota {
+                await self.refreshQuota(force: true)
+            } else {
+                Task { await self.refreshQuota(force: false) }
+            }
         } catch {
             NSLog("[TokenDash] full update error: \(error.localizedDescription)")
             self.state.errorMessage = error.localizedDescription
+        }
+    }
+
+    /// Refresh Coding Plan quotas independently so it never blocks the detail
+    /// paint (upstream provider calls can take 1-2s). `force` bypasses the 60s
+    /// cache — used by the manual refresh button.
+    private func refreshQuota(force: Bool) async {
+        guard let api = apiClient else { return }
+        do {
+            let quotaResp = try await api.getQuota(refresh: force)
+            let merged = retainUsableQuotas(quotaResp.providers, previous: state.quotas)
+            state.quotas = merged
+            NotificationService.shared.evaluate(quotas: merged)
+        } catch {
+            NSLog("[TokenDash] Quota fetch failed (non-fatal): \(error)")
         }
     }
 

--- a/TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift
+++ b/TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift
@@ -24,6 +24,10 @@ import AppKit
     private let activePulseInterval: TimeInterval = 10.0
     private let activeFullInterval: TimeInterval = 60.0
 
+    /// Feature flag matching HourlyChartView.pulseEnabled — hides the 10s pulse
+    /// sampler for the energy-optimization release.
+    private let pulseEnabled = false
+
     private var dormantTimer: Timer?
     private var pulseTimer: Timer?
     private var fullTimer: Timer?
@@ -83,8 +87,10 @@ import AppKit
             // possibly-stale cache. The 60s active detail timer + manual refresh
             // keep it fresh afterwards; only this open moment bypasses the cache.
             Task { await self.performFullUpdate(forceRefresh: true, forceQuota: false) }
-            samplePulse()  // prime a pulse baseline immediately, don't wait 10s
-            schedulePulse()
+            if pulseEnabled {
+                samplePulse()  // prime a pulse baseline immediately, don't wait 10s
+                schedulePulse()
+            }
             scheduleActiveFull()
         case .suspended:
             break   // all data timers stopped; daemon healthCheck (AppDelegate) keeps running
@@ -214,7 +220,7 @@ import AppKit
                 tokens: totalTokens, cost: totalCost,
                 inputTokens: totalInput, outputTokens: totalOutput,
                 cacheReadTokens: totalCacheRead, cacheRate: cacheRate)
-            if dailyResults.count == agents.count {
+            if pulseEnabled, dailyResults.count == agents.count {
                 self.recordPulseObservation(
                     totalTokens: totalTokens, inputTokens: totalInput, outputTokens: totalOutput,
                     date: today, at: Date())

--- a/TokenDashSwift/Sources/TokenDash/DaemonManager.swift
+++ b/TokenDashSwift/Sources/TokenDash/DaemonManager.swift
@@ -198,6 +198,15 @@ import Foundation
         }
     }
 
+    /// Network probe — true if the daemon on the current port responds with
+    /// our package identity. Used by the health monitor; more reliable than
+    /// `isAlive()` (pid-file) across reattach, where self.process is nil and
+    /// pid-file state can lag the actual listener.
+    func isAliveViaProbe() async -> Bool {
+        guard let port = port else { return false }
+        return await probeDaemon(port: port) == .compatible
+    }
+
     private func cleanupIncompatibleDaemon(pid: pid_t?) async {
         if let pid, isProcessAlive(pid: pid), isTokenDashDaemonProcess(pid: pid) {
             await stopDaemonProcessAsync(pid: pid)

--- a/TokenDashSwift/Sources/TokenDash/Models/APIModels.swift
+++ b/TokenDashSwift/Sources/TokenDash/Models/APIModels.swift
@@ -129,6 +129,63 @@ struct HourBucket: Identifiable {
     var id: Int { hour }
 }
 
+/// One five-second observation used by the 30-minute Token Pulse chart.
+struct TokenPulseSample: Codable, Identifiable {
+    let timestamp: Date
+    let tokenDelta: Int
+    let tokensPerSecond: Double
+    let inputDelta: Int
+    let outputDelta: Int
+    let inputTokensPerSecond: Double
+    let outputTokensPerSecond: Double
+    var id: Date { timestamp }
+
+    init(
+        timestamp: Date,
+        tokenDelta: Int,
+        tokensPerSecond: Double,
+        inputDelta: Int = 0,
+        outputDelta: Int = 0,
+        inputTokensPerSecond: Double = 0,
+        outputTokensPerSecond: Double = 0
+    ) {
+        self.timestamp = timestamp
+        self.tokenDelta = tokenDelta
+        self.tokensPerSecond = tokensPerSecond
+        self.inputDelta = inputDelta
+        self.outputDelta = outputDelta
+        self.inputTokensPerSecond = inputTokensPerSecond
+        self.outputTokensPerSecond = outputTokensPerSecond
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case timestamp, tokenDelta, tokensPerSecond
+        case inputDelta, outputDelta, inputTokensPerSecond, outputTokensPerSecond
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        timestamp = try values.decode(Date.self, forKey: .timestamp)
+        tokenDelta = try values.decode(Int.self, forKey: .tokenDelta)
+        tokensPerSecond = try values.decode(Double.self, forKey: .tokensPerSecond)
+        inputDelta = try values.decodeIfPresent(Int.self, forKey: .inputDelta) ?? 0
+        outputDelta = try values.decodeIfPresent(Int.self, forKey: .outputDelta) ?? 0
+        inputTokensPerSecond = try values.decodeIfPresent(Double.self, forKey: .inputTokensPerSecond) ?? 0
+        outputTokensPerSecond = try values.decodeIfPresent(Double.self, forKey: .outputTokensPerSecond) ?? 0
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(timestamp, forKey: .timestamp)
+        try values.encode(tokenDelta, forKey: .tokenDelta)
+        try values.encode(tokensPerSecond, forKey: .tokensPerSecond)
+        try values.encode(inputDelta, forKey: .inputDelta)
+        try values.encode(outputDelta, forKey: .outputDelta)
+        try values.encode(inputTokensPerSecond, forKey: .inputTokensPerSecond)
+        try values.encode(outputTokensPerSecond, forKey: .outputTokensPerSecond)
+    }
+}
+
 struct ProjectRow: Identifiable {
     let name: String
     let fullPath: String

--- a/TokenDashSwift/Sources/TokenDash/Models/AppState.swift
+++ b/TokenDashSwift/Sources/TokenDash/Models/AppState.swift
@@ -22,6 +22,7 @@ import Combine
     var cacheRate: Double = 0
     var todaySummary: TodaySummary?
     var hourlyData: [HourBucket] = []
+    var pulseSamples: [TokenPulseSample] = TokenPulseHistoryStore.shared.load()
     var projects: [ProjectRow] = []
     var models: [ModelRow] = []
     var trend: [TrendPoint] = []

--- a/TokenDashSwift/Sources/TokenDash/Models/TokenPulseHistoryStore.swift
+++ b/TokenDashSwift/Sources/TokenDash/Models/TokenPulseHistoryStore.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Persists the rolling Token Pulse window so closing the popover or restarting
+/// the app never resets the visible 30-minute history.
+final class TokenPulseHistoryStore {
+    static let shared = TokenPulseHistoryStore()
+
+    private let windowDuration: TimeInterval = 30 * 60
+    private let maximumSampleCount = 360
+    private let fileURL: URL
+    private let defaults = UserDefaults.standard
+    private let directionDefinitionVersion = 2
+    private let directionDefinitionKey = "pulse.directionDefinitionVersion"
+
+    private init(fileManager: FileManager = .default) {
+        let applicationSupport = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? fileManager.temporaryDirectory
+        let directory = applicationSupport.appendingPathComponent("TokenDash", isDirectory: true)
+        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        fileURL = directory.appendingPathComponent("pulse-history.json")
+    }
+
+    func load(now: Date = Date()) -> [TokenPulseSample] {
+        guard
+            let data = try? Data(contentsOf: fileURL),
+            let samples = try? JSONDecoder().decode([TokenPulseSample].self, from: data)
+        else {
+            defaults.set(directionDefinitionVersion, forKey: directionDefinitionKey)
+            return []
+        }
+
+        let recent = trimmed(samples, now: now)
+        guard defaults.integer(forKey: directionDefinitionKey) < directionDefinitionVersion else {
+            return recent
+        }
+
+        // Version 1 derived Input from total-output, which incorrectly included
+        // cache usage. Preserve total history but discard its invalid direction.
+        let migrated = recent.map {
+            TokenPulseSample(
+                timestamp: $0.timestamp,
+                tokenDelta: $0.tokenDelta,
+                tokensPerSecond: $0.tokensPerSecond
+            )
+        }
+        defaults.set(directionDefinitionVersion, forKey: directionDefinitionKey)
+        save(migrated, now: now)
+        return migrated
+    }
+
+    func save(_ samples: [TokenPulseSample], now: Date = Date()) {
+        defaults.set(directionDefinitionVersion, forKey: directionDefinitionKey)
+        let recent = trimmed(samples, now: now)
+        guard let data = try? JSONEncoder().encode(recent) else { return }
+
+        do {
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            NSLog("[TokenDash] Failed to persist pulse history: \(error)")
+        }
+    }
+
+    private func trimmed(_ samples: [TokenPulseSample], now: Date) -> [TokenPulseSample] {
+        let cutoff = now.addingTimeInterval(-windowDuration)
+        return samples
+            .filter { $0.timestamp >= cutoff && $0.timestamp <= now.addingTimeInterval(5) }
+            .sorted { $0.timestamp < $1.timestamp }
+            .suffix(maximumSampleCount)
+            .map { $0 }
+    }
+}

--- a/TokenDashSwift/Sources/TokenDash/Models/TokenPulseMetrics.swift
+++ b/TokenDashSwift/Sources/TokenDash/Models/TokenPulseMetrics.swift
@@ -69,3 +69,28 @@ struct TokenPulseMetrics {
         self.isStageActive = isStageActive
     }
 }
+
+/// Trailing-window smoothed token rates, one per sample (sorted ascending by
+/// timestamp, same length as the input). Each output point = Σ token deltas
+/// over samples in `[tᵢ − window, tᵢ]` ÷ `window`.
+///
+/// Using a delta-sum (rather than averaging the per-sample instantaneous rates)
+/// is the key to killing the 0↔spike jitter on the pulse chart: a response that
+/// lands in one 10s bucket is correctly attributed across the whole trailing
+/// window instead of showing up as a single needle. `window` is the divisor
+/// (clamped to ≥ 5s), so a partial window at the chart's leading edge reads as
+/// "past N seconds average including idle time", not an amplified instantaneous.
+func pulseSmoothedRates(
+    for samples: [TokenPulseSample],
+    window: TimeInterval
+) -> [(input: Double, output: Double)] {
+    let ordered = samples.sorted { $0.timestamp < $1.timestamp }
+    let safeWindow = max(5, window)
+    return ordered.map { sample in
+        let windowStart = sample.timestamp.addingTimeInterval(-safeWindow)
+        let inWindow = ordered.filter { $0.timestamp >= windowStart && $0.timestamp <= sample.timestamp }
+        let inputSum = inWindow.reduce(0.0) { $0 + Double(max(0, $1.inputDelta)) }
+        let outputSum = inWindow.reduce(0.0) { $0 + Double(max(0, $1.outputDelta)) }
+        return (input: inputSum / safeWindow, output: outputSum / safeWindow)
+    }
+}

--- a/TokenDashSwift/Sources/TokenDash/Models/TokenPulseMetrics.swift
+++ b/TokenDashSwift/Sources/TokenDash/Models/TokenPulseMetrics.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Separates the latest accounting update from the averages that better
+/// describe sustained work. Provider logs usually publish usage at response
+/// boundaries, so a zero NOW value does not imply that a stream has stopped.
+struct TokenPulseMetrics {
+    let nowRate: Double
+    let stageAverageRate: Double
+    let windowAverageRate: Double
+    let isStageActive: Bool
+
+    static let empty = TokenPulseMetrics(
+        nowRate: 0,
+        stageAverageRate: 0,
+        windowAverageRate: 0,
+        isStageActive: false
+    )
+
+    init(samples: [TokenPulseSample]) {
+        let ordered = samples.sorted { $0.timestamp < $1.timestamp }
+        guard let first = ordered.first, let last = ordered.last else {
+            self = .empty
+            return
+        }
+
+        nowRate = max(0, last.tokensPerSecond)
+
+        let totalTokens = ordered.reduce(0) { $0 + max(0, $1.tokenDelta) }
+        let coveredSeconds = max(5, last.timestamp.timeIntervalSince(first.timestamp) + 5)
+        windowAverageRate = Double(totalTokens) / coveredSeconds
+
+        let positive = ordered.filter { $0.tokenDelta > 0 }
+        guard let latestPositive = positive.last else {
+            stageAverageRate = 0
+            isStageActive = false
+            return
+        }
+
+        // A two-minute gap between accounted responses starts a new stage.
+        // Keep that stage visible for up to five minutes so a long streaming
+        // response is not misrepresented as an immediate stop.
+        let stageGap: TimeInterval = 2 * 60
+        let activeGracePeriod: TimeInterval = 5 * 60
+        var stageStart = latestPositive
+
+        for sample in positive.dropLast().reversed() {
+            if stageStart.timestamp.timeIntervalSince(sample.timestamp) > stageGap {
+                break
+            }
+            stageStart = sample
+        }
+
+        let stageSamples = ordered.filter { $0.timestamp >= stageStart.timestamp }
+        let stageTokens = stageSamples.reduce(0) { $0 + max(0, $1.tokenDelta) }
+        let stageSeconds = max(5, last.timestamp.timeIntervalSince(stageStart.timestamp) + 5)
+        stageAverageRate = Double(stageTokens) / stageSeconds
+        isStageActive = last.timestamp.timeIntervalSince(latestPositive.timestamp) <= activeGracePeriod
+    }
+
+    private init(
+        nowRate: Double,
+        stageAverageRate: Double,
+        windowAverageRate: Double,
+        isStageActive: Bool
+    ) {
+        self.nowRate = nowRate
+        self.stageAverageRate = stageAverageRate
+        self.windowAverageRate = windowAverageRate
+        self.isStageActive = isStageActive
+    }
+}

--- a/TokenDashSwift/Sources/TokenDash/Services/APIClient.swift
+++ b/TokenDashSwift/Sources/TokenDash/Services/APIClient.swift
@@ -1,7 +1,17 @@
 import Foundation
 
+/// Test seam — BadgeUpdater depends on this protocol so unit tests can inject
+/// a counting mock instead of the real HTTP client.
+protocol APIClientProtocol {
+    func getAgents() async throws -> AgentsResponse
+    func getDaily(agent: String, refresh: Bool) async throws -> DailyResponse
+    func getBlocks(agent: String, refresh: Bool) async throws -> BlocksResponse
+    func getProjects(agent: String, refresh: Bool) async throws -> ProjectsResponse
+    func getQuota(refresh: Bool) async throws -> QuotaResponse
+}
+
 /// Lightweight HTTP client for the local TokenDash API.
-actor APIClient {
+actor APIClient: APIClientProtocol {
     static let expectedPackageName = "@zhangferry-dev/tokendash"
     private let baseURL: String
 

--- a/TokenDashSwift/Sources/TokenDash/Views/HourlyChartView.swift
+++ b/TokenDashSwift/Sources/TokenDash/Views/HourlyChartView.swift
@@ -5,6 +5,11 @@ import Charts
 /// point on the curve = Σ token deltas in the past `pulseSmoothWindow` ÷ window.
 private let pulseSmoothWindow: TimeInterval = 30
 
+/// Feature flag: the Pulse tab + its 10s rate-sampling are hidden for the
+/// energy-optimization release (sampling was a top CPU draw). Flip to true to
+/// re-enable both the UI tab and the sampler.
+private let pulseEnabled = false
+
 struct HourlyChartView: View {
     let data: [HourBucket]
     let pulseSamples: [TokenPulseSample]
@@ -43,7 +48,7 @@ struct HourlyChartView: View {
             header
                 .padding(.bottom, 10)
 
-            if selectedMode == .pulse {
+            if pulseEnabled && selectedMode == .pulse {
                 TokenPulseChartView(samples: pulseSamples)
             } else if data.allSatisfy({ $0.tokens == 0 }) {
                 emptyChart
@@ -58,7 +63,7 @@ struct HourlyChartView: View {
 
     private var header: some View {
         HStack(alignment: .center, spacing: 10) {
-            if selectedMode == .pulse {
+            if pulseEnabled && selectedMode == .pulse {
                 HStack(spacing: 5) {
                     Circle()
                         .fill(pulseMetrics.isStageActive ? Color.accentGreen : Color.tertiaryLabel)
@@ -80,7 +85,9 @@ struct HourlyChartView: View {
 
             Spacer()
 
-            modeTabs
+            if pulseEnabled {
+                modeTabs
+            }
         }
     }
 

--- a/TokenDashSwift/Sources/TokenDash/Views/HourlyChartView.swift
+++ b/TokenDashSwift/Sources/TokenDash/Views/HourlyChartView.swift
@@ -3,7 +3,17 @@ import Charts
 
 struct HourlyChartView: View {
     let data: [HourBucket]
+    let pulseSamples: [TokenPulseSample]
+    @State private var selectedMode: ChartMode = .today
     @State private var hoveredHour: Int?
+    @Namespace private var selectorAnimation
+
+    private enum ChartMode: String, CaseIterable, Identifiable {
+        case today = "Today"
+        case pulse = "Pulse"
+
+        var id: Self { self }
+    }
 
     private var currentHour: Int {
         let cal = Calendar.current
@@ -26,13 +36,12 @@ struct HourlyChartView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("HOURLY")
-                .font(.system(size: 11, weight: .semibold))
-                .tracking(0.5)
-                .foregroundStyle(Color.sectionTitleColor)
+            header
                 .padding(.bottom, 10)
 
-            if data.filter({ $0.tokens > 0 }).isEmpty {
+            if selectedMode == .pulse {
+                TokenPulseChartView(samples: pulseSamples)
+            } else if data.allSatisfy({ $0.tokens == 0 }) {
                 emptyChart
             } else {
                 chartArea
@@ -41,6 +50,78 @@ struct HourlyChartView: View {
         .padding(.horizontal, 20)
         .padding(.top, 12)
         .padding(.bottom, 8)
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 10) {
+            if selectedMode == .pulse {
+                HStack(spacing: 5) {
+                    Circle()
+                        .fill(pulseMetrics.isStageActive ? Color.accentGreen : Color.tertiaryLabel)
+                        .frame(width: 6, height: 6)
+                    Text(pulseMetrics.isStageActive ? "STAGE AVG" : "IDLE")
+                        .font(.system(size: 10, weight: .semibold))
+                    Text("\(formatTokenRate(pulseMetrics.isStageActive ? pulseMetrics.stageAverageRate : 0))/s")
+                        .font(.system(size: 10, weight: .medium))
+                        .monospacedDigit()
+                        .foregroundStyle(Color.secondaryLabel)
+                }
+                .foregroundStyle(pulseMetrics.isStageActive ? Color.accentGreen : Color.secondaryLabel)
+            } else {
+                Text("HOURLY")
+                    .font(.system(size: 11, weight: .semibold))
+                    .tracking(0.5)
+                    .foregroundStyle(Color.sectionTitleColor)
+            }
+
+            Spacer()
+
+            modeTabs
+        }
+    }
+
+    private var modeTabs: some View {
+        HStack(spacing: 2) {
+            ForEach(ChartMode.allCases) { mode in
+                Button {
+                    withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
+                        selectedMode = mode
+                    }
+                } label: {
+                    Text(mode.rawValue)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(selectedMode == mode ? Color.white : Color.secondaryLabel)
+                        .padding(.horizontal, 11)
+                        .frame(height: 24)
+                        .background {
+                            if selectedMode == mode {
+                                RoundedRectangle(cornerRadius: 6)
+                                    .fill(Color.accentGreen)
+                                    .matchedGeometryEffect(
+                                        id: "hour-mode-selection",
+                                        in: selectorAnimation
+                                    )
+                            }
+                        }
+                }
+                .buttonStyle(.plain)
+                .accessibilityAddTraits(selectedMode == mode ? .isSelected : [])
+            }
+        }
+        .padding(2)
+        .background(Color.primary.opacity(0.055))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .fixedSize()
+        .animation(.easeInOut(duration: 0.12), value: selectedMode)
+    }
+
+    private var pulseMetrics: TokenPulseMetrics {
+        TokenPulseMetrics(samples: pulseSamples)
+    }
+
+    private func formatTokenRate(_ rate: Double) -> String {
+        let rounded = max(0, Int(rate.rounded()))
+        return rounded < 1_000 ? "\(rounded)" : formatTokens(rounded)
     }
 
     // MARK: - Area chart
@@ -214,5 +295,275 @@ struct HourlyChartView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 20)
+    }
+}
+
+private struct TokenPulseChartView: View {
+    let samples: [TokenPulseSample]
+    @State private var hoverLocation: CGPoint?
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1 / 30)) { timeline in
+            let phase = timeline.date.timeIntervalSinceReferenceDate
+            Canvas { context, size in
+                drawPulse(layout: PulseLayout(samples: samples, size: size), context: &context, phase: phase)
+            }
+        }
+        .frame(height: 110)
+        .overlay(alignment: .topTrailing) {
+            HStack(spacing: 8) {
+                seriesLabel("Input", color: .accentGreen)
+                seriesLabel("Output", color: .blue)
+            }
+            .padding(.top, 1)
+            .padding(.trailing, 2)
+        }
+        .overlay(alignment: .bottomLeading) {
+            Text("30m ago")
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(Color.tertiaryLabel)
+                .padding(.bottom, 1)
+                .padding(.leading, 2)
+        }
+        .overlay(alignment: .bottomTrailing) {
+            Text("now")
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(Color.tertiaryLabel)
+                .padding(.bottom, 1)
+                .padding(.trailing, 2)
+        }
+        // Hover hit-testing covers the whole plot so the tooltip can follow the
+        // cursor anywhere along the 30-minute window.
+        .overlay {
+            Color.clear
+                .contentShape(Rectangle())
+                .onContinuousHover { phase in
+                    switch phase {
+                    case .active(let location):
+                        hoverLocation = location
+                    case .ended:
+                        hoverLocation = nil
+                    }
+                }
+        }
+        // The tooltip floats above the cursor and must never steal hover events
+        // from the clear overlay below, otherwise it flickers on/off.
+        .overlay {
+            GeometryReader { geo in
+                if let hoverLocation {
+                    let layout = PulseLayout(samples: samples, size: geo.size)
+                    if let sample = layout.sample(atX: hoverLocation.x) {
+                        pulseTooltip(for: sample)
+                            .position(
+                                x: min(max(hoverLocation.x, 64), max(64, geo.size.width - 64)),
+                                y: 16
+                            )
+                    }
+                }
+            }
+            .allowsHitTesting(false)
+        }
+    }
+
+    private func seriesLabel(_ label: String, color: Color) -> some View {
+        HStack(spacing: 3) {
+            Circle()
+                .fill(color)
+                .frame(width: 5, height: 5)
+            Text(label)
+                .foregroundStyle(Color.secondaryLabel)
+        }
+        .font(.system(size: 9, weight: .medium))
+    }
+
+    private func formatRate(_ rate: Double) -> String {
+        let value = max(0, Int(rate.rounded()))
+        return value < 1_000 ? "\(value)" : formatTokens(value)
+    }
+
+    private func pulseTimeString(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter.string(from: date)
+    }
+
+    private func pulseTooltip(for sample: TokenPulseSample) -> some View {
+        VStack(spacing: 1) {
+            Text(pulseTimeString(sample.timestamp))
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(.secondary)
+            HStack(spacing: 6) {
+                Text("↑ \(formatRate(sample.inputTokensPerSecond))/s")
+                    .foregroundStyle(Color.accentGreen)
+                Text("↓ \(formatRate(sample.outputTokensPerSecond))/s")
+                    .foregroundStyle(Color.blue)
+            }
+            .font(.system(size: 10, weight: .semibold))
+        }
+        .padding(.horizontal, 7)
+        .padding(.vertical, 5)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 6))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(.primary.opacity(0.08), lineWidth: 0.5)
+        }
+    }
+
+    private func drawPulse(layout: PulseLayout, context: inout GraphicsContext, phase: TimeInterval) {
+        let size = layout.size
+
+        context.stroke(
+            Path { path in
+                path.move(to: CGPoint(x: 0, y: layout.baselineY))
+                path.addLine(to: CGPoint(x: size.width, y: layout.baselineY))
+            },
+            with: .color(Color.primary.opacity(0.10)),
+            lineWidth: 0.5
+        )
+
+        guard !layout.samples.isEmpty else { return }
+
+        let inputLine = smoothPath(through: layout.inputPoints)
+        let outputLine = smoothPath(through: layout.outputPoints)
+
+        var inputFill = inputLine
+        if let first = layout.inputPoints.first, let last = layout.inputPoints.last {
+            inputFill.addLine(to: CGPoint(x: last.x, y: layout.baselineY))
+            inputFill.addLine(to: CGPoint(x: first.x, y: layout.baselineY))
+            inputFill.closeSubpath()
+        }
+
+        var outputFill = outputLine
+        if let first = layout.outputPoints.first, let last = layout.outputPoints.last {
+            outputFill.addLine(to: CGPoint(x: last.x, y: layout.baselineY))
+            outputFill.addLine(to: CGPoint(x: first.x, y: layout.baselineY))
+            outputFill.closeSubpath()
+        }
+
+        context.fill(inputFill, with: .color(Color.accentGreen.opacity(0.45)))
+        context.fill(outputFill, with: .color(Color.blue.opacity(0.45)))
+
+        context.stroke(
+            inputLine,
+            with: .color(Color.accentGreen),
+            style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round)
+        )
+        context.stroke(
+            outputLine,
+            with: .color(Color.blue),
+            style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round)
+        )
+
+        let pulse = 0.5 + 0.5 * sin(phase * 3.2)
+        let latestInput = layout.samples.last?.inputTokensPerSecond ?? 0
+        let latestOutput = layout.samples.last?.outputTokensPerSecond ?? 0
+        let activeEndPoint: CGPoint
+        let activeColor: Color
+        if latestOutput > latestInput {
+            activeEndPoint = layout.outputPoints.last ?? CGPoint(x: size.width, y: layout.baselineY)
+            activeColor = .blue
+        } else {
+            activeEndPoint = layout.inputPoints.last ?? CGPoint(x: size.width, y: layout.baselineY)
+            activeColor = .accentGreen
+        }
+        context.fill(
+            Path(ellipseIn: CGRect(
+                x: activeEndPoint.x - 11 - CGFloat(pulse) * 3,
+                y: activeEndPoint.y - 11 - CGFloat(pulse) * 3,
+                width: 22 + CGFloat(pulse) * 6,
+                height: 22 + CGFloat(pulse) * 6
+            )),
+            with: .color(activeColor.opacity(0.10))
+        )
+        context.fill(
+            Path(ellipseIn: CGRect(
+                x: activeEndPoint.x - 4.5,
+                y: activeEndPoint.y - 4.5,
+                width: 9,
+                height: 9
+            )),
+            with: .color(activeColor)
+        )
+    }
+
+    /// Smooth Catmull-Rom spline through the given points, rendered as a path of
+    /// cubic Bézier segments. Tension 0.5 produces the gentle, continuous curve
+    /// that the previous straight `addLine` joins were missing.
+    private func smoothPath(through points: [CGPoint], tension: CGFloat = 0.5) -> Path {
+        var path = Path()
+        guard let first = points.first else { return path }
+        path.move(to: first)
+        guard points.count > 1 else { return path }
+        if points.count == 2 {
+            path.addLine(to: points[1])
+            return path
+        }
+        let k = tension / 3
+        for index in 0..<(points.count - 1) {
+            let p0 = index == 0 ? points[0] : points[index - 1]
+            let p1 = points[index]
+            let p2 = points[index + 1]
+            let p3 = index + 2 < points.count ? points[index + 2] : points[index + 1]
+            let control1 = CGPoint(x: p1.x + (p2.x - p0.x) * k, y: p1.y + (p2.y - p0.y) * k)
+            let control2 = CGPoint(x: p2.x - (p3.x - p1.x) * k, y: p2.y - (p3.y - p1.y) * k)
+            path.addCurve(to: p2, control1: control1, control2: control2)
+        }
+        return path
+    }
+}
+
+/// Pre-computed geometry for the pulse chart. The canvas renderer and the hover
+/// hit-testing share one layout so a cursor position maps to exactly the sample
+/// the eye sees on the curve.
+private struct PulseLayout {
+    let size: CGSize
+    let topPadding: CGFloat = 8
+    let bottomPadding: CGFloat = 22
+    let baselineY: CGFloat
+    let sharedPeakRate: Double
+    let samples: [TokenPulseSample]
+    let inputPoints: [CGPoint]
+    let outputPoints: [CGPoint]
+    let windowStart: Date
+
+    init(samples: [TokenPulseSample], size: CGSize) {
+        self.samples = samples
+        self.size = size
+        // Input rises above the baseline, output drops below it — two mirrored
+        // translucent bands sharing one midline.
+        let chartHeight = max(1, size.height - topPadding - bottomPadding)
+        baselineY = topPadding + chartHeight * 0.52
+        let upperHeight = chartHeight * 0.44
+        let lowerHeight = chartHeight * 0.40
+        let now = samples.last?.timestamp ?? Date()
+        windowStart = now.addingTimeInterval(-30 * 60)
+        sharedPeakRate = max(
+            samples.map(\.inputTokensPerSecond).max() ?? 0,
+            samples.map(\.outputTokensPerSecond).max() ?? 0,
+            1
+        )
+
+        var inputs: [CGPoint] = []
+        var outputs: [CGPoint] = []
+        for sample in samples {
+            let elapsed = sample.timestamp.timeIntervalSince(windowStart)
+            let x = size.width * CGFloat(max(0, min(1, elapsed / (30 * 60))))
+            let normalizedInput = log1p(sample.inputTokensPerSecond) / log1p(sharedPeakRate)
+            let normalizedOutput = log1p(sample.outputTokensPerSecond) / log1p(sharedPeakRate)
+            inputs.append(CGPoint(x: x, y: baselineY - upperHeight * CGFloat(normalizedInput)))
+            outputs.append(CGPoint(x: x, y: baselineY + lowerHeight * CGFloat(normalizedOutput)))
+        }
+        inputPoints = inputs
+        outputPoints = outputs
+    }
+
+    /// Map a horizontal position (0…width) to the nearest sample in time.
+    func sample(atX x: CGFloat) -> TokenPulseSample? {
+        guard !samples.isEmpty, size.width > 0 else { return nil }
+        let fraction = max(0, min(1, x / size.width))
+        let target = windowStart.addingTimeInterval(fraction * 30 * 60)
+        return samples.min {
+            abs($0.timestamp.timeIntervalSince(target)) < abs($1.timestamp.timeIntervalSince(target))
+        }
     }
 }

--- a/TokenDashSwift/Sources/TokenDash/Views/HourlyChartView.swift
+++ b/TokenDashSwift/Sources/TokenDash/Views/HourlyChartView.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 import Charts
 
+/// Trailing window for the pulse chart's smoothed rate curve (seconds). Each
+/// point on the curve = Σ token deltas in the past `pulseSmoothWindow` ÷ window.
+private let pulseSmoothWindow: TimeInterval = 30
+
 struct HourlyChartView: View {
     let data: [HourBucket]
     let pulseSamples: [TokenPulseSample]
@@ -353,7 +357,9 @@ private struct TokenPulseChartView: View {
                 if let hoverLocation {
                     let layout = PulseLayout(samples: samples, size: geo.size)
                     if let sample = layout.sample(atX: hoverLocation.x) {
-                        pulseTooltip(for: sample)
+                        let rate = layout.smoothedRate(for: sample)
+                            ?? (input: sample.inputTokensPerSecond, output: sample.outputTokensPerSecond)
+                        pulseTooltip(timestamp: sample.timestamp, input: rate.input, output: rate.output)
                             .position(
                                 x: min(max(hoverLocation.x, 64), max(64, geo.size.width - 64)),
                                 y: 16
@@ -387,15 +393,15 @@ private struct TokenPulseChartView: View {
         return formatter.string(from: date)
     }
 
-    private func pulseTooltip(for sample: TokenPulseSample) -> some View {
+    private func pulseTooltip(timestamp: Date, input: Double, output: Double) -> some View {
         VStack(spacing: 1) {
-            Text(pulseTimeString(sample.timestamp))
+            Text(pulseTimeString(timestamp))
                 .font(.system(size: 9, weight: .medium))
                 .foregroundStyle(.secondary)
             HStack(spacing: 6) {
-                Text("↑ \(formatRate(sample.inputTokensPerSecond))/s")
+                Text("↑ \(formatRate(input))/s")
                     .foregroundStyle(Color.accentGreen)
-                Text("↓ \(formatRate(sample.outputTokensPerSecond))/s")
+                Text("↓ \(formatRate(output))/s")
                     .foregroundStyle(Color.blue)
             }
             .font(.system(size: 10, weight: .semibold))
@@ -522,12 +528,14 @@ private struct PulseLayout {
     let baselineY: CGFloat
     let sharedPeakRate: Double
     let samples: [TokenPulseSample]
+    let rates: [(input: Double, output: Double)]
     let inputPoints: [CGPoint]
     let outputPoints: [CGPoint]
     let windowStart: Date
 
     init(samples: [TokenPulseSample], size: CGSize) {
-        self.samples = samples
+        let sorted = samples.sorted { $0.timestamp < $1.timestamp }
+        self.samples = sorted
         self.size = size
         // Input rises above the baseline, output drops below it — two mirrored
         // translucent bands sharing one midline.
@@ -535,26 +543,39 @@ private struct PulseLayout {
         baselineY = topPadding + chartHeight * 0.52
         let upperHeight = chartHeight * 0.44
         let lowerHeight = chartHeight * 0.40
-        let now = samples.last?.timestamp ?? Date()
+        let now = sorted.last?.timestamp ?? Date()
         windowStart = now.addingTimeInterval(-30 * 60)
+
+        // Smoothed trailing-window rates — kills the 0↔spike jitter from batched
+        // JSONL writes by spreading each response's tokens across the window.
+        let rates = pulseSmoothedRates(for: sorted, window: pulseSmoothWindow)
+        self.rates = rates
         sharedPeakRate = max(
-            samples.map(\.inputTokensPerSecond).max() ?? 0,
-            samples.map(\.outputTokensPerSecond).max() ?? 0,
+            rates.map(\.input).max() ?? 0,
+            rates.map(\.output).max() ?? 0,
             1
         )
 
         var inputs: [CGPoint] = []
         var outputs: [CGPoint] = []
-        for sample in samples {
+        for (index, sample) in sorted.enumerated() {
             let elapsed = sample.timestamp.timeIntervalSince(windowStart)
             let x = size.width * CGFloat(max(0, min(1, elapsed / (30 * 60))))
-            let normalizedInput = log1p(sample.inputTokensPerSecond) / log1p(sharedPeakRate)
-            let normalizedOutput = log1p(sample.outputTokensPerSecond) / log1p(sharedPeakRate)
+            let rate = rates[index]
+            let normalizedInput = log1p(rate.input) / log1p(sharedPeakRate)
+            let normalizedOutput = log1p(rate.output) / log1p(sharedPeakRate)
             inputs.append(CGPoint(x: x, y: baselineY - upperHeight * CGFloat(normalizedInput)))
             outputs.append(CGPoint(x: x, y: baselineY + lowerHeight * CGFloat(normalizedOutput)))
         }
         inputPoints = inputs
         outputPoints = outputs
+    }
+
+    /// Smoothed (input, output) rate for a given sample, for the hover tooltip.
+    func smoothedRate(for sample: TokenPulseSample) -> (input: Double, output: Double)? {
+        guard let index = samples.firstIndex(where: { $0.timestamp == sample.timestamp }),
+              index < rates.count else { return nil }
+        return rates[index]
     }
 
     /// Map a horizontal position (0…width) to the nearest sample in time.

--- a/TokenDashSwift/Sources/TokenDash/Views/PopoverView.swift
+++ b/TokenDashSwift/Sources/TokenDash/Views/PopoverView.swift
@@ -37,7 +37,7 @@ struct PopoverView: View {
             if state.isLoading {
                 loadingContent
             } else {
-                HourlyChartView(data: state.hourlyData)
+                HourlyChartView(data: state.hourlyData, pulseSamples: state.pulseSamples)
                     .sectionDivider()
 
                 UsageSection(summary: state.todaySummary, models: state.models)

--- a/TokenDashSwift/Sources/TokenDash/Views/UsageSection.swift
+++ b/TokenDashSwift/Sources/TokenDash/Views/UsageSection.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
-/// Usage breakdown with a By Model / By Type toggle.
+/// Usage breakdown with a Model / Type toggle.
 ///
-/// By Model shows per-model token share (Sonnet/Opus/Haiku/…), a dimension the
-/// old single Input/Output/Cached breakdown lacked. By Type keeps that classic
+/// Model shows per-model token share (Sonnet/Opus/Haiku/…), a dimension the
+/// old single Input/Output/Cached breakdown lacked. Type keeps that classic
 /// split. Both share one compact bar-list renderer.
 struct UsageSection: View {
     let summary: TodaySummary?
@@ -12,8 +12,8 @@ struct UsageSection: View {
     @Namespace private var selectorAnimation
 
     private enum Mode: String, CaseIterable, Identifiable {
-        case model = "By Model"
-        case type = "By Type"
+        case model = "Model"
+        case type = "Type"
         var id: String { rawValue }
     }
 

--- a/TokenDashSwift/Tests/TokenDashTests/BadgeUpdaterModeTests.swift
+++ b/TokenDashSwift/Tests/TokenDashTests/BadgeUpdaterModeTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import TokenDash
+
+@MainActor
+final class BadgeUpdaterModeTests: XCTestCase {
+
+    // MARK: - dormant: badge 更新只拉 daily，不拉 blocks/projects/quota
+
+    func testDormantPerformBadgeUpdateSkipsBlocksProjectsQuota() async throws {
+        let state = AppState()
+        let mock = MockAPIClient()
+        let updater = BadgeUpdater(state: state, client: mock)
+
+        await updater.performBadgeUpdate()
+
+        let counts = await mock.snapshot()
+        XCTAssertGreaterThan(counts.daily, 0, "dormant badge 更新必须拉 daily")
+        XCTAssertEqual(counts.blocks, 0, "dormant 不得拉 blocks")
+        XCTAssertEqual(counts.projects, 0, "dormant 不得拉 projects")
+        XCTAssertEqual(counts.quota, 0, "dormant 不得拉 quota")
+    }
+
+    // MARK: - active: 打开瞬间全量拉详情，但 quota 走缓存（refresh=false）
+
+    func testActivePerformFullUpdateFetchesDetailsButCachesQuota() async throws {
+        let state = AppState()
+        let mock = MockAPIClient()
+        let updater = BadgeUpdater(state: state, client: mock)
+
+        await updater.performFullUpdate(forceRefresh: true, forceQuota: false)
+
+        let counts = await mock.snapshot()
+        XCTAssertGreaterThan(counts.daily, 0)
+        XCTAssertGreaterThan(counts.blocks, 0)
+        XCTAssertGreaterThan(counts.projects, 0)
+        XCTAssertGreaterThan(counts.quota, 0, "active 详情刷新要拉 quota")
+        let lastQuotaRefresh = await mock.lastQuotaRefresh
+        XCTAssertEqual(lastQuotaRefresh, false, "非手动刷新时 quota 必须走缓存")
+    }
+
+    // MARK: - 手动刷新：quota 强刷
+
+    func testManualRefreshForceRefreshesQuota() async throws {
+        let state = AppState()
+        let mock = MockAPIClient()
+        let updater = BadgeUpdater(state: state, client: mock)
+
+        await updater.performFullUpdate(forceRefresh: true, forceQuota: true)
+
+        let lastQuotaRefresh = await mock.lastQuotaRefresh
+        XCTAssertEqual(lastQuotaRefresh, true, "手动刷新必须强刷 quota")
+    }
+}
+
+/// 计数型 mock — 记录每个端点被调用的次数与关键参数，供模式断言。
+actor MockAPIClient: APIClientProtocol {
+    private(set) var agents = 0
+    private(set) var daily = 0
+    private(set) var blocks = 0
+    private(set) var projects = 0
+    private(set) var quota = 0
+    private(set) var lastQuotaRefresh: Bool? = nil
+
+    struct Snapshot {
+        let agents: Int; let daily: Int; let blocks: Int
+        let projects: Int; let quota: Int
+    }
+    func snapshot() -> Snapshot {
+        Snapshot(agents: agents, daily: daily, blocks: blocks, projects: projects, quota: quota)
+    }
+
+    func getAgents() async throws -> AgentsResponse {
+        agents += 1
+        return AgentsResponse(available: ["claude"], default: "claude")
+    }
+    func getDaily(agent: String, refresh: Bool) async throws -> DailyResponse {
+        daily += 1
+        return DailyResponse(daily: [])
+    }
+    func getBlocks(agent: String, refresh: Bool) async throws -> BlocksResponse {
+        blocks += 1
+        return BlocksResponse(blocks: [])
+    }
+    func getProjects(agent: String, refresh: Bool) async throws -> ProjectsResponse {
+        projects += 1
+        return ProjectsResponse(projects: [:])
+    }
+    func getQuota(refresh: Bool) async throws -> QuotaResponse {
+        quota += 1
+        lastQuotaRefresh = refresh
+        return QuotaResponse(providers: [])
+    }
+}

--- a/TokenDashSwift/Tests/TokenDashTests/BadgeUpdaterModeTests.swift
+++ b/TokenDashSwift/Tests/TokenDashTests/BadgeUpdaterModeTests.swift
@@ -28,12 +28,15 @@ final class BadgeUpdaterModeTests: XCTestCase {
         let updater = BadgeUpdater(state: state, client: mock)
 
         await updater.performFullUpdate(forceRefresh: true, forceQuota: false)
+        // Detail state paints synchronously; quota refreshes async — give the
+        // detached quota task a moment to run before asserting on it.
+        try await Task.sleep(nanoseconds: 200_000_000)  // 0.2s
 
         let counts = await mock.snapshot()
         XCTAssertGreaterThan(counts.daily, 0)
         XCTAssertGreaterThan(counts.blocks, 0)
         XCTAssertGreaterThan(counts.projects, 0)
-        XCTAssertGreaterThan(counts.quota, 0, "active 详情刷新要拉 quota")
+        XCTAssertGreaterThan(counts.quota, 0, "active 详情刷新最终要拉 quota（异步）")
         let lastQuotaRefresh = await mock.lastQuotaRefresh
         XCTAssertEqual(lastQuotaRefresh, false, "非手动刷新时 quota 必须走缓存")
     }

--- a/TokenDashSwift/Tests/TokenDashTests/PulseSmoothedRatesTests.swift
+++ b/TokenDashSwift/Tests/TokenDashTests/PulseSmoothedRatesTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import TokenDash
+
+final class PulseSmoothedRatesTests: XCTestCase {
+    private func sample(_ t: TimeInterval, input: Int, output: Int) -> TokenPulseSample {
+        TokenPulseSample(
+            timestamp: Date(timeIntervalSinceReferenceDate: t),
+            tokenDelta: input + output,
+            tokensPerSecond: 0,
+            inputDelta: input,
+            outputDelta: output
+        )
+    }
+
+    func testEmptyReturnsEmpty() {
+        XCTAssertEqual(pulseSmoothedRates(for: [], window: 30).count, 0)
+    }
+
+    func testSingleSampleAveragesOverWindow() {
+        // one sample, delta 300 spread over the 30s window -> 10/s
+        let rates = pulseSmoothedRates(for: [sample(100, input: 300, output: 0)], window: 30)
+        XCTAssertEqual(rates.count, 1)
+        XCTAssertEqual(rates[0].input, 10, accuracy: 0.001)
+        XCTAssertEqual(rates[0].output, 0, accuracy: 0.001)
+    }
+
+    func testTrailingWindowSumsDeltas() {
+        // 3 samples at t=0,10,20 (each input 300). window=30s.
+        let samples = [
+            sample(0, input: 300, output: 0),
+            sample(10, input: 300, output: 0),
+            sample(20, input: 300, output: 0),
+        ]
+        let rates = pulseSmoothedRates(for: samples, window: 30)
+        // t=0:  only sample 0 (300) in [-30,0]  -> 10/s
+        XCTAssertEqual(rates[0].input, 10, accuracy: 0.001)
+        // t=10: samples 0+1 (600) in [-20,10]  -> 20/s
+        XCTAssertEqual(rates[1].input, 20, accuracy: 0.001)
+        // t=20: samples 0+1+2 (900) in [-10,20] -> 30/s
+        XCTAssertEqual(rates[2].input, 30, accuracy: 0.001)
+    }
+
+    func testSpikeAttributedAcrossWindowNotOneNeedle() {
+        // A single big response (delta 3000) at t=0 must raise the rate for
+        // every point within 30s after it, then drop to 0 — not vanish into a
+        // one-sample needle.
+        var samples: [TokenPulseSample] = [sample(0, input: 3000, output: 0)]
+        for t in stride(from: 10.0, through: 60.0, by: 10.0) {
+            samples.append(sample(t, input: 0, output: 0))
+        }
+        let rates = pulseSmoothedRates(for: samples, window: 30)
+        // t=0:  3000/30 = 100
+        XCTAssertEqual(rates[0].input, 100, accuracy: 0.001)
+        // t=30 (index 3): t=0 still inside [0,30] -> 100
+        XCTAssertEqual(rates[3].input, 100, accuracy: 0.001)
+        // t=40 (index 4): t=0 now outside [10,40] -> 0
+        XCTAssertEqual(rates[4].input, 0, accuracy: 0.001)
+    }
+
+    func testClampsUndersizedWindow() {
+        // window <= 0 is clamped to 5s so we never divide by ~0.
+        let rates = pulseSmoothedRates(for: [sample(0, input: 50, output: 0)], window: 0)
+        XCTAssertEqual(rates[0].input, 10, accuracy: 0.001) // 50 / max(5, 0) = 10
+    }
+}

--- a/TokenDashSwift/Tests/TokenDashTests/TokenPulseMetricsTests.swift
+++ b/TokenDashSwift/Tests/TokenDashTests/TokenPulseMetricsTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import TokenDash
+
+final class TokenPulseMetricsTests: XCTestCase {
+    func testSeparatesNowStageAndWindowRates() {
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        let samples = [
+            sample(at: start, delta: 0, rate: 0),
+            sample(at: start.addingTimeInterval(5), delta: 1_000, rate: 200),
+            sample(at: start.addingTimeInterval(10), delta: 0, rate: 0),
+        ]
+
+        let metrics = TokenPulseMetrics(samples: samples)
+
+        XCTAssertEqual(metrics.nowRate, 0)
+        XCTAssertEqual(metrics.stageAverageRate, 100, accuracy: 0.001)
+        XCTAssertEqual(metrics.windowAverageRate, 1_000 / 15, accuracy: 0.001)
+        XCTAssertTrue(metrics.isStageActive)
+    }
+
+    func testStartsNewStageAfterTwoMinuteGap() {
+        let start = Date(timeIntervalSinceReferenceDate: 2_000)
+        let samples = [
+            sample(at: start, delta: 1_000, rate: 200),
+            sample(at: start.addingTimeInterval(180), delta: 600, rate: 120),
+            sample(at: start.addingTimeInterval(185), delta: 0, rate: 0),
+        ]
+
+        let metrics = TokenPulseMetrics(samples: samples)
+
+        XCTAssertEqual(metrics.stageAverageRate, 60, accuracy: 0.001)
+        XCTAssertTrue(metrics.isStageActive)
+    }
+
+    func testStageBecomesIdleAfterGracePeriod() {
+        let start = Date(timeIntervalSinceReferenceDate: 3_000)
+        let samples = [
+            sample(at: start, delta: 1_000, rate: 200),
+            sample(at: start.addingTimeInterval(301), delta: 0, rate: 0),
+        ]
+
+        XCTAssertFalse(TokenPulseMetrics(samples: samples).isStageActive)
+    }
+
+    func testLegacyPersistedSampleDefaultsMissingInputAndOutputToZero() throws {
+        let json = """
+        {"timestamp":1000,"tokenDelta":500,"tokensPerSecond":100}
+        """
+
+        let sample = try JSONDecoder().decode(TokenPulseSample.self, from: Data(json.utf8))
+
+        XCTAssertEqual(sample.inputDelta, 0)
+        XCTAssertEqual(sample.outputDelta, 0)
+        XCTAssertEqual(sample.inputTokensPerSecond, 0)
+        XCTAssertEqual(sample.outputTokensPerSecond, 0)
+    }
+
+    private func sample(at timestamp: Date, delta: Int, rate: Double) -> TokenPulseSample {
+        TokenPulseSample(timestamp: timestamp, tokenDelta: delta, tokensPerSecond: rate)
+    }
+}

--- a/docs/superpowers/plans/2026-07-03-tokendash-energy-optimization.md
+++ b/docs/superpowers/plans/2026-07-03-tokendash-energy-optimization.md
@@ -1,0 +1,843 @@
+# TokenDash 能耗优化（方案 A+ 自适应刷新）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 TokenDash 菜单栏的后台刷新从「无脑 5s 强解析」改成「popover 可见性 + 系统电源驱动的 dormant/active/suspended 三态」，让 popover 合上时 CPU 归零、打开时全速无损。
+
+**Architecture:** `BadgeUpdater` 引入 `RefreshMode` 状态机，由 `AppDelegate` 在 NSPanel 开闭与系统睡眠/低电量通知时切换模式。每个模式只调度它需要的定时器：dormant 仅 60s（用户设置）轻量 badge 更新走 daemon 缓存；active 全量刷新 + 10s 脉冲 + 60s 详情缓存刷新；suspended 全停。daemon 端零改动——Swift 端把 `refresh:true` 改成 `refresh:false` 即可命中现有 5min usage 缓存与 60s quota 缓存。
+
+**Tech Stack:** Swift / SwiftUI / AppKit（NSPanel + NSStatusItem）/ XCTest / Node daemon（零改动）。
+
+**Spec:** `docs/superpowers/specs/2026-07-03-tokendash-energy-optimization-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `TokenDashSwift/Sources/TokenDash/Services/APIClient.swift`
+  - 新增 `APIClientProtocol`，`APIClient` 遵循它。为 BadgeUpdater 注入 mock 提供测试 seam。
+- **Modify** `TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift`（核心重构）
+  - 加 `RefreshMode` 状态机 + `setMode(_:)` + 三个独立定时器（dormant / active-pulse / active-full）。
+  - 拆 `update()` 为 `performBadgeUpdate()`（轻，dormant）与 `performFullUpdate(forceRefresh:forceQuota:)`（重，active）。
+  - `samplePulse()` 仅 active 调度；`refresh:false` 走缓存；`refreshNow()` 手动强刷含 quota。
+- **Modify** `TokenDashSwift/Sources/TokenDash/App.swift`
+  - `togglePopover()` 显示后 `setMode(.active)`；`hidePopover()` 后 `setMode(.dormant)`。
+  - 注册 `NSWorkspace.willSleep/didWakeNotification` + `NSProcessInfoPowerStateDidChange`，驱动 suspended。
+- **Create** `TokenDashSwift/Tests/TokenDashTests/BadgeUpdaterModeTests.swift`
+  - XCTest，用 `MockAPIClient`（actor）计数，验证 dormant 不拉 blocks/projects/quota、active 走缓存。
+- **daemon 端零改动**（已确认 `src/server/routes/daily.ts:14` 与 `api.ts:17` 在无 `refresh=1` 时走缓存）。
+
+---
+
+## Task 1: 抽出 `APIClientProtocol`（可测试性前置）
+
+**Files:**
+- Modify: `TokenDashSwift/Sources/TokenDash/Services/APIClient.swift`
+
+- [ ] **Step 1: 在 `APIClient.swift` 顶部（`actor APIClient` 之前）新增协议**
+
+在 `import Foundation` 之后、`actor APIClient` 之前插入：
+
+```swift
+/// Test seam — BadgeUpdater depends on this protocol so unit tests can inject
+/// a counting mock instead of the real HTTP client.
+protocol APIClientProtocol {
+    func getAgents() async throws -> AgentsResponse
+    func getDaily(agent: String, refresh: Bool) async throws -> DailyResponse
+    func getBlocks(agent: String, refresh: Bool) async throws -> BlocksResponse
+    func getProjects(agent: String, refresh: Bool) async throws -> ProjectsResponse
+    func getQuota(refresh: Bool) async throws -> QuotaResponse
+}
+```
+
+- [ ] **Step 2: 让 `APIClient` 遵循协议**
+
+把 `actor APIClient {` 改为：
+
+```swift
+actor APIClient: APIClientProtocol {
+```
+
+现有方法签名已与协议匹配（默认参数值不计入协议要求，无需改动方法体）。
+
+- [ ] **Step 3: 验证编译**
+
+Run: `swift build --package-path TokenDashSwift 2>&1 | tail -20`
+Expected: `Build complete!`（无错误）
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TokenDashSwift/Sources/TokenDash/Services/APIClient.swift
+git commit -m "Introduce APIClientProtocol as a test seam for BadgeUpdater"
+```
+
+---
+
+## Task 2: `BadgeUpdater` 状态机重构（核心）
+
+**Files:**
+- Modify: `TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift`（整体替换）
+
+- [ ] **Step 1: 先写失败的模式测试**
+
+Create `TokenDashSwift/Tests/TokenDashTests/BadgeUpdaterModeTests.swift`:
+
+```swift
+import XCTest
+@testable import TokenDash
+
+@MainActor
+final class BadgeUpdaterModeTests: XCTestCase {
+
+    // MARK: - dormant: badge 更新只拉 daily，不拉 blocks/projects/quota
+
+    func testDormantPerformBadgeUpdateSkipsBlocksProjectsQuota() async throws {
+        let state = AppState()
+        let mock = MockAPIClient()
+        let updater = BadgeUpdater(state: state, client: mock)
+
+        await updater.performBadgeUpdate()
+
+        let counts = await mock.snapshot()
+        XCTAssertGreaterThan(counts.daily, 0, "dormant badge 更新必须拉 daily")
+        XCTAssertEqual(counts.blocks, 0, "dormant 不得拉 blocks")
+        XCTAssertEqual(counts.projects, 0, "dormant 不得拉 projects")
+        XCTAssertEqual(counts.quota, 0, "dormant 不得拉 quota")
+    }
+
+    // MARK: - active: 打开瞬间全量拉详情，但 quota 走缓存（refresh=false）
+
+    func testActivePerformFullUpdateFetchesDetailsButCachesQuota() async throws {
+        let state = AppState()
+        let mock = MockAPIClient()
+        let updater = BadgeUpdater(state: state, client: mock)
+
+        await updater.performFullUpdate(forceRefresh: true, forceQuota: false)
+
+        let counts = await mock.snapshot()
+        XCTAssertGreaterThan(counts.daily, 0)
+        XCTAssertGreaterThan(counts.blocks, 0)
+        XCTAssertGreaterThan(counts.projects, 0)
+        XCTAssertGreaterThan(counts.quota, 0, "active 详情刷新要拉 quota")
+        let lastQuotaRefresh = await mock.lastQuotaRefresh
+        XCTAssertEqual(lastQuotaRefresh, false, "非手动刷新时 quota 必须走缓存")
+    }
+
+    // MARK: - 手动刷新：quota 强刷
+
+    func testManualRefreshForceRefreshesQuota() async throws {
+        let state = AppState()
+        let mock = MockAPIClient()
+        let updater = BadgeUpdater(state: state, client: mock)
+
+        await updater.performFullUpdate(forceRefresh: true, forceQuota: true)
+
+        let lastQuotaRefresh = await mock.lastQuotaRefresh
+        XCTAssertEqual(lastQuotaRefresh, true, "手动刷新必须强刷 quota")
+    }
+}
+```
+
+- [ ] **Step 2: 写 MockAPIClient（同文件，测试辅助）**
+
+在 `BadgeUpdaterModeTests.swift` 末尾追加：
+
+```swift
+/// 计数型 mock — 记录每个端点被调用的次数与关键参数，供模式断言。
+actor MockAPIClient: APIClientProtocol {
+    private(set) var agents = 0
+    private(set) var daily = 0
+    private(set) var blocks = 0
+    private(set) var projects = 0
+    private(set) var quota = 0
+    private(set) var lastQuotaRefresh: Bool? = nil
+
+    struct Snapshot {
+        let agents: Int; let daily: Int; let blocks: Int
+        let projects: Int; let quota: Int
+    }
+    func snapshot() -> Snapshot {
+        Snapshot(agents: agents, daily: daily, blocks: blocks, projects: projects, quota: quota)
+    }
+
+    func getAgents() async throws -> AgentsResponse {
+        agents += 1
+        return AgentsResponse(available: ["claude"], default: "claude")
+    }
+    func getDaily(agent: String, refresh: Bool) async throws -> DailyResponse {
+        daily += 1
+        return DailyResponse(daily: [])
+    }
+    func getBlocks(agent: String, refresh: Bool) async throws -> BlocksResponse {
+        blocks += 1
+        return BlocksResponse(blocks: [])
+    }
+    func getProjects(agent: String, refresh: Bool) async throws -> ProjectsResponse {
+        projects += 1
+        return ProjectsResponse(projects: [:])
+    }
+    func getQuota(refresh: Bool) async throws -> QuotaResponse {
+        quota += 1
+        lastQuotaRefresh = refresh
+        return QuotaResponse(providers: [])
+    }
+}
+```
+
+- [ ] **Step 3: 运行测试确认失败（BadgeUpdater 新 API 尚未实现）**
+
+Run: `swift test --package-path TokenDashSwift --filter BadgeUpdaterModeTests 2>&1 | tail -30`
+Expected: 编译失败 —— `BadgeUpdater` 没有 `init(state:client:)`、`performBadgeUpdate()`、`performFullUpdate(forceRefresh:forceQuota:)`。
+
+- [ ] **Step 4: 整体替换 `BadgeUpdater.swift` 为重构版**
+
+Replace the entire contents of `TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift` with:
+
+```swift
+import Foundation
+import AppKit
+
+/// Periodically fetches usage data from the API, updates the menu bar badge image
+/// and refreshes the shared AppState for the popover.
+///
+/// Refresh is driven by a three-state machine (`RefreshMode`) instead of a fixed
+/// high-frequency timer:
+/// - `.dormant`  — popover closed: only the cheap badge update (today total),
+///                 served from the daemon cache. No pulse, no details, no quota.
+/// - `.active`   — popover open: immediate full refresh + 10s pulse (refresh,
+///                 for rate deltas) + 60s cached detail refresh.
+/// - `.suspended`— system sleep / low power: all data timers stopped.
+@MainActor class BadgeUpdater {
+    private let state: AppState
+    private var apiClient: any APIClientProtocol?
+
+    enum RefreshMode { case dormant, active, suspended }
+    private(set) var mode: RefreshMode = .dormant
+
+    // Cadences (seconds). dormant reuses the user's SettingsStore.refreshInterval
+    // (it is cache-served, so even 30s stays cheap). active cadences are fixed.
+    private var dormantInterval: TimeInterval { SettingsStore.shared.refreshInterval.rawValue }
+    private let activePulseInterval: TimeInterval = 10.0
+    private let activeFullInterval: TimeInterval = 60.0
+
+    private var dormantTimer: Timer?
+    private var pulseTimer: Timer?
+    private var fullTimer: Timer?
+
+    private var activeAgents: [String] = []
+    private var isPulseSampling = false
+    private var lastPulseObservation: (
+        date: String,
+        timestamp: Date,
+        totalTokens: Int,
+        inputTokens: Int,
+        outputTokens: Int
+    )?
+
+    init(state: AppState, client: (any APIClientProtocol)? = nil) {
+        self.state = state
+        self.apiClient = client
+    }
+
+    func start(port: Int) {
+        applyPort(port)
+        setMode(.dormant)   // app launches with popover hidden
+    }
+
+    /// Hot-switch to a new daemon port after restart, preserving the current mode.
+    func updatePort(_ port: Int) {
+        let resumeMode = mode
+        applyPort(port)
+        NSLog("[TokenDash] BadgeUpdater switched to port \(port)")
+        mode = .suspended     // force setMode to rebuild timers against new port
+        setMode(resumeMode)
+    }
+
+    private func applyPort(_ port: Int) {
+        self.apiClient = APIClient(port: port)
+        self.state.daemonPort = port
+        self.state.isDaemonReady = true
+        self.state.errorMessage = nil
+    }
+
+    // MARK: - Mode state machine
+
+    func setMode(_ newMode: RefreshMode) {
+        mode = newMode
+        stopDataTimers()
+        switch newMode {
+        case .dormant:
+            scheduleDormant()
+            Task { await self.performBadgeUpdate() }   // immediate refresh on entry
+        case .active:
+            Task { await self.performFullUpdate(forceRefresh: true, forceQuota: false) }
+            schedulePulse()
+            scheduleActiveFull()
+        case .suspended:
+            break   // all data timers stopped; daemon healthCheck (AppDelegate) keeps running
+        }
+        NSLog("[TokenDash] BadgeUpdater mode → \(newMode)")
+    }
+
+    private func scheduleDormant() {
+        let t = Timer(timeInterval: dormantInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in await self?.performBadgeUpdate() }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        dormantTimer = t
+    }
+
+    private func schedulePulse() {
+        let t = Timer(timeInterval: activePulseInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.samplePulse() }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        pulseTimer = t
+    }
+
+    private func scheduleActiveFull() {
+        let t = Timer(timeInterval: activeFullInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in await self?.performFullUpdate(forceRefresh: false, forceQuota: false) }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        fullTimer = t
+    }
+
+    private func stopDataTimers() {
+        dormantTimer?.invalidate(); dormantTimer = nil
+        pulseTimer?.invalidate(); pulseTimer = nil
+        fullTimer?.invalidate(); fullTimer = nil
+    }
+
+    func stop() {
+        stopDataTimers()
+    }
+
+    /// Manual refresh (refresh button) — force everything, including external quota.
+    func refreshNow() {
+        Task { await self.performFullUpdate(forceRefresh: true, forceQuota: true) }
+    }
+
+    // MARK: - dormant: cheap badge update (cache-served)
+
+    /// Updates only today's total tokens + cost for the menu bar badge. Served
+    /// from the daemon's 5min cache (refresh:false) so it never triggers JSONL
+    /// re-parsing. Does not touch detail state (hourly/projects/trend/quota).
+    func performBadgeUpdate() async {
+        guard let api = apiClient else { return }
+        do {
+            let agentsResp = try await api.getAgents()
+            let agents = agentsResp.available.isEmpty ? ["claude"] : agentsResp.available
+            self.activeAgents = agents
+
+            let today = todayString()
+            var totalTokens = 0
+            var totalCost = 0.0
+            for agent in agents {
+                if let d = try? await api.getDaily(agent: agent, refresh: false) {
+                    if let entry = d.daily.first(where: { $0.date == today }) {
+                        totalTokens += entry.totalTokens
+                        totalCost += entry.totalCost
+                    }
+                }
+            }
+
+            let tokenStr = formatTokens(totalTokens)
+            self.state.badgeImage = Self.renderBadgeImage(title: tokenStr)
+            self.state.tooltipText = String(
+                format: "TokenDash - %@ tokens today ($%.2f)", tokenStr, totalCost)
+            self.state.isLoading = false
+            self.state.errorMessage = nil
+        } catch {
+            NSLog("[TokenDash] badge update error: \(error.localizedDescription)")
+            self.state.errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - active: full popover refresh
+
+    /// Full refresh for the open popover: daily + blocks + projects + quota +
+    /// derived hourly/projects/models/trend. `forceRefresh` bypasses the daemon
+    /// usage cache (used on popover open); `forceQuota` bypasses the 60s quota
+    /// cache (manual refresh only).
+    func performFullUpdate(forceRefresh: Bool, forceQuota: Bool) async {
+        guard let api = apiClient else {
+            NSLog("[TokenDash] performFullUpdate called but apiClient is nil")
+            return
+        }
+        do {
+            let agentsResp = try await api.getAgents()
+            let agents = agentsResp.available.isEmpty ? ["claude"] : agentsResp.available
+            self.activeAgents = agents
+
+            var dailyResults: [DailyResponse] = []
+            var blockResults: [BlocksResponse] = []
+            var projectResults: [ProjectsResponse] = []
+
+            for agent in agents {
+                if let d = try? await api.getDaily(agent: agent, refresh: forceRefresh) { dailyResults.append(d) }
+                // Detail endpoints always cache-served (refresh:false) — daemon reuses its
+                // 5min cache, so the 60s active cadence does NOT re-parse JSONL.
+                if let b = try? await api.getBlocks(agent: agent, refresh: false) { blockResults.append(b) }
+                if let p = try? await api.getProjects(agent: agent, refresh: false) { projectResults.append(p) }
+            }
+
+            let today = todayString()
+            var totalTokens = 0, totalInput = 0, totalOutput = 0, totalCacheRead = 0
+            var totalCost = 0.0
+            for data in dailyResults {
+                guard let entry = data.daily.first(where: { $0.date == today }) else { continue }
+                totalTokens += entry.totalTokens
+                totalInput += entry.inputTokens
+                totalOutput += entry.outputTokens
+                totalCacheRead += entry.cacheReadTokens
+                totalCost += entry.totalCost
+            }
+            let denom = Double(totalInput + totalCacheRead)
+            let cacheRate = denom > 0 ? Double(totalCacheRead) / denom * 100 : 0
+            let tokenStr = formatTokens(totalTokens)
+            let badgeImage = Self.renderBadgeImage(title: tokenStr)
+            let summary = TodaySummary(
+                tokens: totalTokens, cost: totalCost,
+                inputTokens: totalInput, outputTokens: totalOutput,
+                cacheReadTokens: totalCacheRead, cacheRate: cacheRate)
+            if dailyResults.count == agents.count {
+                self.recordPulseObservation(
+                    totalTokens: totalTokens, inputTokens: totalInput, outputTokens: totalOutput,
+                    date: today, at: Date())
+            }
+            let hourly = computeHourly(blocks: blockResults, today: today)
+            let projectRows = computeProjects(projects: projectResults, today: today)
+            let modelRows = computeModels(daily: dailyResults, today: today)
+            let trendPoints = computeTrend(daily: dailyResults)
+
+            // Coding Plan quotas — cache-served unless this is a manual refresh.
+            var quotaSnapshots = self.state.quotas
+            do {
+                let quotaResp = try await api.getQuota(refresh: forceQuota)
+                quotaSnapshots = self.retainUsableQuotas(quotaResp.providers, previous: self.state.quotas)
+            } catch {
+                NSLog("[TokenDash] Quota fetch failed (non-fatal): \(error)")
+            }
+
+            self.state.badgeImage = badgeImage
+            self.state.tooltipText = String(
+                format: "TokenDash - %@ tokens today ($%.2f) | cache: %.1f%%",
+                tokenStr, totalCost, cacheRate)
+            self.state.todaySummary = summary
+            self.state.cacheRate = cacheRate
+            self.state.isLoading = false
+            self.state.errorMessage = nil
+            self.state.hourlyData = hourly
+            self.state.projects = projectRows
+            self.state.models = modelRows
+            self.state.trend = trendPoints
+            self.state.quotas = quotaSnapshots
+
+            NotificationService.shared.evaluate(quotas: quotaSnapshots)
+        } catch {
+            NSLog("[TokenDash] full update error: \(error.localizedDescription)")
+            self.state.errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Pulse sampling (active only)
+
+    /// Samples today's cumulative token count every activePulseInterval. refresh:true
+    /// because rate deltas need fresh totals (a cache-served value would freeze the
+    /// rate chart at zero). Only scheduled in `.active`.
+    private func samplePulse() {
+        guard let api = apiClient, !isPulseSampling else { return }
+        isPulseSampling = true
+        Task { [weak self] in
+            guard let self else { return }
+            defer { self.isPulseSampling = false }
+            do {
+                let agents = self.activeAgents.isEmpty
+                    ? (try await api.getAgents().available.isEmpty ? ["claude"] : try await api.getAgents().available)
+                    : self.activeAgents
+                let today = self.todayString()
+                var totalTokens = 0, inputTokens = 0, outputTokens = 0, ok = 0
+                for agent in agents {
+                    do {
+                        let r = try await api.getDaily(agent: agent, refresh: true)
+                        if let e = r.daily.first(where: { $0.date == today }) {
+                            totalTokens += e.totalTokens
+                            inputTokens += e.inputTokens
+                            outputTokens += e.outputTokens
+                        }
+                        ok += 1
+                    } catch { NSLog("[TokenDash] Pulse sample failed for \(agent): \(error)") }
+                }
+                guard ok == agents.count else { return }
+                self.recordPulseObservation(
+                    totalTokens: totalTokens, inputTokens: inputTokens, outputTokens: outputTokens,
+                    date: today, at: Date())
+            } catch {
+                NSLog("[TokenDash] Pulse sampling failed: \(error)")
+            }
+        }
+    }
+
+    private func recordPulseObservation(
+        totalTokens: Int, inputTokens: Int, outputTokens: Int, date: String, at timestamp: Date
+    ) {
+        guard let previous = lastPulseObservation, previous.date == date else {
+            lastPulseObservation = (date, timestamp, totalTokens, inputTokens, outputTokens)
+            if let latest = state.pulseSamples.last,
+               !Calendar.current.isDate(latest.timestamp, inSameDayAs: timestamp) {
+                state.pulseSamples = []
+                TokenPulseHistoryStore.shared.save([], now: timestamp)
+            }
+            return
+        }
+        let elapsed = timestamp.timeIntervalSince(previous.timestamp)
+        guard elapsed > 0 else { return }
+        let delta = totalTokens >= previous.totalTokens ? totalTokens - previous.totalTokens : 0
+        let inputDelta = inputTokens >= previous.inputTokens ? inputTokens - previous.inputTokens : 0
+        let outputDelta = outputTokens >= previous.outputTokens ? outputTokens - previous.outputTokens : 0
+        let sample = TokenPulseSample(
+            timestamp: timestamp, tokenDelta: delta, tokensPerSecond: Double(delta) / elapsed,
+            inputDelta: inputDelta, outputTokensPerSecond: Double(outputDelta) / elapsed,
+            inputTokensPerSecond: Double(inputDelta) / elapsed,
+            outputDelta: outputDelta)
+        let _ = sample  // silence unused-warning path if any
+        let cutoff = timestamp.addingTimeInterval(-30 * 60)
+        state.pulseSamples = (state.pulseSamples + [sample])
+            .filter { $0.timestamp >= cutoff }.suffix(360).map { $0 }
+        TokenPulseHistoryStore.shared.save(state.pulseSamples, now: timestamp)
+        lastPulseObservation = (date, timestamp, totalTokens, inputTokens, outputTokens)
+    }
+
+    private func retainUsableQuotas(_ incoming: [QuotaSnapshot], previous: [QuotaSnapshot]) -> [QuotaSnapshot] {
+        guard !incoming.isEmpty else { return previous }
+        let previousByProvider = Dictionary(uniqueKeysWithValues: previous.map { ($0.provider, $0) })
+        var retainedProviders = Set<String>()
+        var merged = incoming.compactMap { snapshot -> QuotaSnapshot? in
+            retainedProviders.insert(snapshot.provider)
+            if snapshot.status.state == "ok", snapshot.freshness != "stale", !snapshot.windows.isEmpty {
+                return snapshot
+            }
+            return previousByProvider[snapshot.provider]
+        }
+        for snapshot in previous where !retainedProviders.contains(snapshot.provider) { merged.append(snapshot) }
+        return merged
+    }
+
+    // MARK: - Data computation (unchanged from prior implementation)
+
+    private func computeHourly(blocks: [BlocksResponse], today: String) -> [HourBucket] {
+        var hourly = [Int](repeating: 0, count: 24)
+        for resp in blocks {
+            for block in resp.blocks {
+                let prefix = String(block.startTime.prefix(10))
+                guard prefix == today else { continue }
+                let hourStr = block.startTime.count >= 13 ? String(block.startTime.prefix(13).suffix(2)) : ""
+                if let h = Int(hourStr), h >= 0, h < 24 { hourly[h] += block.totalTokens }
+            }
+        }
+        let maxVal = hourly.max() ?? 0
+        return (0..<24).map { h in HourBucket(hour: h, tokens: hourly[h], isPeak: hourly[h] > 0 && hourly[h] == maxVal) }
+    }
+
+    private func computeProjects(projects: [ProjectsResponse], today: String) -> [ProjectRow] {
+        var totals: [String: (input: Int, output: Int, cached: Int, total: Int)] = [:]
+        for resp in projects {
+            for (path, entries) in resp.projects {
+                let todayEntries = entries.filter { $0.date == today }
+                guard !todayEntries.isEmpty else { continue }
+                var t = totals[path] ?? (0, 0, 0, 0)
+                for e in todayEntries {
+                    t.input += e.inputTokens; t.output += e.outputTokens
+                    t.cached += e.cacheReadTokens; t.total += e.totalTokens
+                }
+                totals[path] = t
+            }
+        }
+        return totals.map { path, t in
+            ProjectRow(name: formatProjectName(path), fullPath: path, input: t.input, output: t.output, cached: t.cached, total: t.total)
+        }.sorted { $0.total > $1.total }.prefix(4).map { $0 }
+    }
+
+    private func computeModels(daily: [DailyResponse], today: String) -> [ModelRow] {
+        var totals: [String: (tokens: Int, cost: Double)] = [:]
+        for data in daily {
+            guard let entry = data.daily.first(where: { $0.date == today }) else { continue }
+            for b in entry.modelBreakdowns ?? [] {
+                let name = shortModelName(b.modelName)
+                var t = totals[name] ?? (0, 0)
+                t.tokens += b.inputTokens + b.outputTokens + b.cacheReadTokens
+                t.cost += b.cost
+                totals[name] = t
+            }
+        }
+        return totals.map { name, t in ModelRow(name: name, tokens: t.tokens, cost: t.cost) }
+            .sorted { $0.tokens > $1.tokens }.prefix(5).map { $0 }
+    }
+
+    private func computeTrend(daily: [DailyResponse]) -> [TrendPoint] {
+        var byDate: [String: (tokens: Int, cost: Double)] = [:]
+        for data in daily {
+            for entry in data.daily {
+                var t = byDate[entry.date] ?? (0, 0)
+                t.tokens += entry.totalTokens; t.cost += entry.totalCost
+                byDate[entry.date] = t
+            }
+        }
+        let fmt = DateFormatter(); fmt.dateFormat = "yyyy-MM-dd"
+        let cal = Calendar.current
+        let todayStart = cal.startOfDay(for: Date())
+        return (0..<7).reversed().map { i in
+            guard let d = cal.date(byAdding: .day, value: -i, to: todayStart) else {
+                return TrendPoint(date: "", tokens: 0, cost: 0)
+            }
+            let key = fmt.string(from: d)
+            let t = byDate[key] ?? (0, 0)
+            return TrendPoint(date: key, tokens: t.tokens, cost: t.cost)
+        }
+    }
+
+    // MARK: - Badge image rendering (unchanged)
+
+    static func renderBadgeImage(title: String) -> NSImage {
+        let iconW: CGFloat = 18, iconH: CGFloat = 18
+        let fontSize: CGFloat = 13
+        let font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .medium)
+        let textAttrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.black]
+        let textWidth = (title as NSString).size(withAttributes: textAttrs).width
+        let padding: CGFloat = 4
+        let totalWidth = iconW + padding + textWidth
+        let totalHeight: CGFloat = 20
+        let image = NSImage(size: NSSize(width: totalWidth, height: totalHeight))
+        image.lockFocus()
+        let icon = createTemplateIcon(size: NSSize(width: iconW, height: iconH))
+        icon.draw(in: NSRect(x: 0, y: (totalHeight - iconH) / 2.0, width: iconW, height: iconH))
+        let textY = (totalHeight - fontSize) / 2.0 - 1
+        (title as NSString).draw(at: NSPoint(x: iconW + padding, y: textY), withAttributes: textAttrs)
+        image.unlockFocus()
+        image.isTemplate = true
+        return image
+    }
+
+    private static func createTemplateIcon(size: NSSize) -> NSImage {
+        let image = NSImage(size: size)
+        image.lockFocus()
+        let inset = min(size.width, size.height) * 0.08
+        let circleRect = NSRect(x: inset, y: inset, width: size.width - inset * 2, height: size.height - inset * 2)
+        NSColor.black.setFill()
+        NSBezierPath(ovalIn: circleRect).fill()
+        let sx = size.width / 64.0, sy = size.height / 64.0
+        let path = NSBezierPath()
+        path.move(to: NSPoint(x: 7 * sx, y: 32 * sy))
+        path.line(to: NSPoint(x: 25 * sx, y: 32 * sy))
+        path.line(to: NSPoint(x: 31 * sx, y: 47 * sy))
+        path.line(to: NSPoint(x: 38 * sx, y: 17 * sy))
+        path.line(to: NSPoint(x: 44 * sx, y: 32 * sy))
+        path.line(to: NSPoint(x: 57 * sx, y: 32 * sy))
+        path.lineWidth = 5.5 * sx
+        path.lineCapStyle = .round; path.lineJoinStyle = .round
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current?.compositingOperation = .clear
+        path.stroke()
+        NSGraphicsContext.restoreGraphicsState()
+        image.unlockFocus()
+        image.isTemplate = true
+        return image
+    }
+}
+```
+
+> **Note on `samplePulse` agent reload:** the original always re-fetched agents lazily; the refactor reuses `activeAgents` (populated by the full update on popover open) and only falls back to `getAgents()` when empty, trimming one network call per pulse tick.
+
+- [ ] **Step 5: 运行测试确认通过**
+
+Run: `swift test --package-path TokenDashSwift --filter BadgeUpdaterModeTests 2>&1 | tail -30`
+Expected: 3 个测试全部 PASS。
+
+- [ ] **Step 6: 运行全部测试确认无回归**
+
+Run: `swift test --package-path TokenDashSwift 2>&1 | tail -30`
+Expected: 全部 PASS（含既有 `TokenPulseMetricsTests`）。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift TokenDashSwift/Tests/TokenDashTests/BadgeUpdaterModeTests.swift
+git commit -m "Refactor BadgeUpdater into dormant/active/suspended refresh state machine"
+```
+
+---
+
+## Task 3: `AppDelegate` 集成模式切换 + 系统电源感知
+
+**Files:**
+- Modify: `TokenDashSwift/Sources/TokenDash/App.swift`
+
+- [ ] **Step 1: 在 `togglePopover()` 的显示分支末尾（`startOutsideClickMonitor()` 之后）切 active**
+
+定位 `App.swift` 中 `togglePopover()` 的 `else` 分支，在 `startOutsideClickMonitor()` 之后加一行：
+
+```swift
+            panel.orderFrontRegardless()
+            panel.makeKey()
+            startOutsideClickMonitor()
+            badgeUpdater?.setMode(.active)   // ← 新增
+```
+
+- [ ] **Step 2: 在 `hidePopover()` 中（`orderOut` 之后）切 dormant**
+
+```swift
+    private func hidePopover() {
+        panel.orderOut(nil)
+        stopOutsideClickMonitor()
+        badgeUpdater?.setMode(.dormant)     // ← 新增
+    }
+```
+
+- [ ] **Step 3: 在 `applicationDidFinishLaunching` 里注册电源通知**
+
+在 `daemonHealthTimer = Timer.scheduledTimer(...)` 之后、`DispatchQueue.main.async { ... }` 之前插入：
+
+```swift
+        // Power awareness: suspend the refresh state machine on sleep / low power
+        // so the menu bar stops polling entirely while the system is idle.
+        let ws = NSWorkspace.shared.notificationCenter
+        ws.addObserver(self, selector: #selector(systemWillSleep),
+                       name: NSWorkspace.willSleepNotification, object: nil)
+        ws.addObserver(self, selector: #selector(systemDidWake),
+                       name: NSWorkspace.didWakeNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(powerStateChanged),
+            name: Notification.Name.NSProcessInfoPowerStateDidChange, object: nil)
+```
+
+- [ ] **Step 4: 新增三个 `@objc` 电源回调方法**
+
+在 `checkDaemonHealth()` 方法之后（`applicationWillTerminate` 之前）插入：
+
+```swift
+    // MARK: - Power state → refresh mode
+
+    @objc private func systemWillSleep() {
+        badgeUpdater?.setMode(.suspended)
+    }
+
+    @objc private func systemDidWake() {
+        // Wake up with popover hidden → dormant. (If the popover was open when
+        // sleeping, the user will click again and togglePopover flips to active.)
+        badgeUpdater?.setMode(.dormant)
+    }
+
+    @objc private func powerStateChanged() {
+        if ProcessInfo.processInfo.isLowPowerModeEnabled {
+            badgeUpdater?.setMode(.suspended)
+        }
+        // Exiting low-power mode does not auto-resume; the next popover toggle
+        // or sleep/wake cycle restarts the appropriate mode.
+    }
+```
+
+- [ ] **Step 5: 验证编译**
+
+Run: `swift build --package-path TokenDashSwift 2>&1 | tail -20`
+Expected: `Build complete!`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TokenDashSwift/Sources/TokenDash/App.swift
+git commit -m "Drive BadgeUpdater mode from popover visibility and power notifications"
+```
+
+---
+
+## Task 4: 构建、本地热更新、验收
+
+> 项目约定（CLAUDE.md）：每次改完自动重新构建并启动，不让用户手动操作。复用 cerebrum 2026-06-19 记录的「只改 Swift 代码的本地更新捷径」——替换二进制 + add_rpath + 重签 + open，免跑完整 package-app.sh。
+
+**Files:** 无（验证 + 部署）
+
+- [ ] **Step 1: 完整构建 + 测试**
+
+Run: `swift test --package-path TokenDashSwift 2>&1 | tail -15`
+Expected: 全部 PASS。
+
+- [ ] **Step 2: 退出当前运行的 TokenDash**
+
+Run: `pkill -x TokenDash 2>/dev/null; sleep 1; echo "stopped"`
+Expected: `stopped`（或无输出，若未在运行）。
+
+- [ ] **Step 3: 替换二进制 + 修 rpath + 重签**
+
+Run（一行一行执行，任一失败立即停下排查）：
+
+```bash
+cp TokenDashSwift/.build/debug/TokenDash /Applications/TokenDash.app/Contents/MacOS/TokenDash && \
+install_name_tool -add_rpath '@executable_path/../Frameworks' /Applications/TokenDash.app/Contents/MacOS/TokenDash 2>/dev/null; \
+codesign --force --sign - /Applications/TokenDash.app/Contents/MacOS/TokenDash && \
+codesign --force --sign - --deep /Applications/TokenDash.app && \
+echo "replaced+signed"
+```
+Expected: `replaced+signed`。（`install_name_tool` 若 rpath 已存在会非零退出，被 `;` 吞掉，无妨。）
+
+- [ ] **Step 4: 启动新版**
+
+Run: `open /Applications/TokenDash.app && sleep 3 && echo "launched"`
+Expected: `launched`，菜单栏出现 TokenDash 图标。
+
+- [ ] **Step 5: 验收 dormant 期 CPU 归零（核心指标）**
+
+人工 + 命令结合：
+1. 让 popover 保持关闭 ≥5 分钟（不要点开）。
+2. 期间 TokenDash daemon 端口（默认 3456，或 `~/.tokendash/daemon.port`）不应被频繁请求。可抽查看请求频率：
+
+Run: `lsof -i :$(cat ~/.tokendash/daemon.port 2>/dev/null || echo 3456) -nP 2>/dev/null | head -5`
+（仅确认 daemon 在监听。CPU 用「活动监视器」观察 TokenDash 与 node 进程，dormant 期平均 CPU 应接近 0、< 0.5%。）
+
+3. 点开 popover：确认 1s 内出现完整数据（hourly/projects/trend/quota 卡片），实时速率图每 ~10s 跳动一次。
+4. 关闭 popover：确认速率图停止刷新（不再每 10s 拉）。
+5. **回归检查**：badge 数字仍在更新；quota 卡片显示正常；Dashboard 按钮（`http://127.0.0.1:<port>`）可打开；手动点刷新按钮触发一次强刷。
+
+- [ ] **Step 6: 验收 daemon 自愈未受影响**
+
+Run: `pkill -f daemon.cjs 2>/dev/null; sleep 35; ls ~/.tokendash/daemon.pid 2>/dev/null && echo "self-healed" || echo "MISSING"`
+Expected: 约 30s 内 `self-healed`（`AppDelegate.checkDaemonHealth` 重启 daemon，BadgeUpdater.updatePort 热切换，模式保持）。
+
+- [ ] **Step 7: 更新 CHANGELOG（如需发版）**
+
+如本次将随版本发布，在 `CHANGELOG.md` 顶部加一条「省电：菜单栏后台改为按需刷新，popover 合上时 CPU 归零」。否则跳过。
+
+- [ ] **Step 8: 收尾 commit（如 Step 7 改了 CHANGELOG）**
+
+```bash
+git add CHANGELOG.md
+git commit -m "Note energy optimization in changelog"
+```
+
+---
+
+## Self-Review（计划作者自查，已做）
+
+- **Spec 覆盖**：
+  - 5.1 状态机三态 → Task 2 `RefreshMode` + Task 3 触发。✓
+  - 5.2 updateBadge/updateFull 拆分 + refresh:false + 手动强刷 → Task 2 Step 4 + 测试。✓
+  - 5.3 daemon 零改动（缓存已存在）→ 已确认 `daily.ts:14`/`api.ts:17`。✓
+  - 5.4 daemon 自愈保持 → Task 4 Step 6 验证。✓
+  - 5.5 单测 + 手动验收 → Task 2 测试 + Task 4 Step 5。✓
+  - 第 6 节决策（脉冲 10s / quota 走缓存仅手动强刷 / dormant 复用用户刷新间隔）→ Task 2 代码。✓
+  - 第 8 节验收标准 1-5 → Task 4 Step 5-6。✓
+- **占位符扫描**：无 TBD/TODO；所有代码步骤含完整代码。✓
+- **类型一致性**：`RefreshMode`、`performBadgeUpdate()`、`performFullUpdate(forceRefresh:forceQuota:)`、`setMode(_:)`、`APIClientProtocol` 在 Task 1-3 与测试间命名一致。✓
+- **简化说明**：spec 5.1 写「低电量降级 dormant 到 120s」，本计划简化为「低电量 → suspended」（更省电、实现更简）；若后续需要 120s dormant，可加一个 `.dormantLowPower` 模式。已在 Task 3 Step 4 注释说明。
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-07-03-tokendash-energy-optimization.md`. Two execution options:**
+
+1. **Subagent-Driven (recommended)** — 每个 task 派一个新 subagent，task 间我来 review，迭代快。
+2. **Inline Execution** — 在当前会话按 executing-plans 批量执行，带 checkpoint。
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-07-03-pulse-chart-smoothing-design.md
+++ b/docs/superpowers/specs/2026-07-03-pulse-chart-smoothing-design.md
@@ -1,0 +1,53 @@
+# Pulse Chart 平滑（trailing 30s 速率）
+
+- **日期**: 2026-07-03
+- **状态**: Draft（待用户审核）
+- **范围**: `HourlyChartView.swift` 的 Pulse 折线平滑
+- **作者**: brainstorming 会话产出
+
+## 1. 背景
+
+脉冲折线（Pulse tab）画的 y 值是每个采样点的**瞬时** input/output 速率（`inputTokensPerSecond = 10s 窗口 token delta / 10s`，见 `HourlyChartView.swift:551-554`）。因 JSONL 在**响应结束时才批量写入** token，10s 采样窗口要么恰好抓到一次响应结束（大 delta → 尖峰），要么没抓到（delta=0），瞬时速率在 0/尖峰间反复跳，折线尖刺、忽上忽下。
+
+header 的「STAGE AVG」数字已用 `stageAverageRate`（跨阶段平均）平滑，但**折线没**——所以"数字稳、曲线尖"。Catmull-Rom 只平滑线，平滑不了数据抖。
+
+## 2. 方案
+
+**trailing 30s 窗口速率**：每个折线点 = 过去 30s 内所有 sample 的 `tokenDelta` 求和 ÷ 30s。
+
+- 用 delta 求和（不是"平均瞬时速率"），正确归因跨采样窗口的 token——不会因响应刚好落在哪个 10s 窗口而丢峰或重复计。
+- 30s ≈ 3 个采样点（10s 间隔），平衡平滑与实时；停止后约 30s 回落到 0。
+- 用户选定（"更实时"取向）。
+
+## 3. 实现（仅 `HourlyChartView.swift`）
+
+1. **抽纯函数** `smoothedRates(for samples: [TokenPulseSample], window: TimeInterval) -> [(input: Double, output: Double)]`：
+   - 对每个 sample `i`，取时间在 `[tᵢ − window, tᵢ]` 内的所有 sample，`Σ inputDelta` / `Σ outputDelta`，除以 `max(5, tᵢ − t_最早)`（窗口不足时按实际覆盖时长，避免除以过小值放大噪声）。
+   - 顶部常量 `private let pulseSmoothWindow: TimeInterval = 30`。
+
+2. **`PulseLayout`**：用 smoothed rate 算 `inputPoints`/`outputPoints`（log1p 归一化不变）；`sharedPeakRate` 改用 smoothed rate 的 max（峰值随之降低，归一化一致）。
+
+3. **tooltip**：显示该点 smoothed rate（与折线一致），不再显示瞬时抖动值。
+
+4. **不动**：
+   - 右端脉动「活跃指示点」：仍用 `samples.last` 瞬时值定颜色 + 脉动（保留实时感）。
+   - header「STAGE AVG」：仍用 `stageAverageRate`。
+   - 采样逻辑（`BadgeUpdater.samplePulse`）：不变。
+
+## 4. 测试
+
+- `smoothedRates` 单测（XCTest，放 `Tests/TokenDashTests/`）：窗口满（3 点求和）、窗口不足（首个 sample 仅自身）、全零、跨窗口 token 归因（一个大 delta 只算进它之后 30s 内的点）。
+- 手动：曲线连贯不尖刺；停止生成后约 30s 回落。
+
+## 5. 验收
+
+1. 折线连贯平滑，无瞬时尖刺（0↔尖峰跳变消失）。
+2. header STAGE AVG、活跃指示点脉动行为不变。
+3. tooltip 显示平滑值，hover 各点速率与折线视觉一致。
+4. 现有 `TokenPulseMetricsTests` 不回归。
+
+## 6. 范围
+
+**In scope**：`HourlyChartView.swift`（PulseLayout + drawPulse tooltip + 抽函数）、新单测。
+
+**Out of scope**：采样频率/窗口可配置化（本次固定 30s 常量）、header 设计改动。

--- a/docs/superpowers/specs/2026-07-03-tokendash-energy-optimization-design.md
+++ b/docs/superpowers/specs/2026-07-03-tokendash-energy-optimization-design.md
@@ -1,0 +1,154 @@
+# TokenDash 能耗优化设计（方案 A+：自适应按需刷新）
+
+- **日期**: 2026-07-03
+- **状态**: Draft（待用户审核）
+- **范围**: TokenDash 菜单栏 app（Swift）+ Node daemon 的后台轮询能耗优化
+- **作者**: brainstorming 会话产出
+
+---
+
+## 1. 背景
+
+用户反馈 TokenDash 后台常驻能耗偏高，活动监视器中 TokenDash / tokendash daemon 进程 CPU 占用明显。TokenDash 是 **Swift 菜单栏 app + 常驻 Node daemon** 双进程结构，真正的耗电不在「进程常驻」本身（Node 事件循环闲置很省），而在于**不管用户是否在看，都在高频干活**。
+
+## 2. 能耗诊断（代码定位）
+
+按严重度，三个热点：
+
+1. **每 5 秒强制重解析日志（最大头）**
+   `BadgeUpdater` 有固定 5s tick（`BadgeUpdater.swift:12`，注释自称 "cheap"，但实际不然）。`tick()` 在非刷新周期调用 `samplePulse()`（`:76`），后者对每个 agent 请求 `getDaily(refresh: true)`（`:108`）。`refresh:true` 绕过 daemon 缓存，**重新扫描 `~/.claude/projects/` 等目录解析 JSONL**。等于：用户没看菜单栏，也每 5 秒扫盘+解析一次；会话文件越多 CPU 越高。目的是画「实时 token 速率」脉冲图。
+
+2. **每次刷新全量算 popover 所有图表（不管开没开）**
+   `update()`（`:180`）无条件计算 hourly/projects/models/trend 并拉 quota，写多个 `@Observable` 触发 SwiftUI。但菜单栏 badge 只需要「今日总 token 数」一个值，其余仅 popover 打开时才用得到。
+
+3. **每次刷新强打外部 quota API**
+   `getQuota(refresh:true)`（`:274`）每周期清掉 daemon 的 60s `QuotaCache`，重新请求 GLM/MiniMax/Kimi/Codex 外部接口。
+
+**非热点**：daemon 常驻本身、`DaemonManager` 30s healthCheck（`isAlive` 不走网络，廉价）。
+
+核心矛盾：**「实时性」被实现成无脑高频轮询，而 95% 时间用户没在看。**
+
+## 3. 竞品调研：exelban/stats
+
+参考 [exelban/stats](https://github.com/exelban/stats)——持续监控网络/系统但功耗约为 TokenDash 的 1%。其省电三根支柱：
+
+| 支柱 | stats 做法 | TokenDash 可借鉴性 |
+|---|---|---|
+| **① 数据源 inherently 廉价** | 读内核 API（`host_statistics`/`getifaddrs`/SMC），O(1) 微秒级、零磁盘 I/O | **搬不了**——统计 token 用量必须扫日志文件，这是业务本质，也是两者功耗差 ~100× 的根因 |
+| **② 同步刷新（Synchronized）** | 所有模块共享一个 timer，一次唤醒做完所有读取+UI 更新 | **已满足**——`BadgeUpdater` 已是单一 Timer |
+| **③ 按需启停模块** | 不显示的模块不跑 timer（官方 FAQ：禁用不用的模块降 ~50% CPU） | **可搬**——对应「popover 详情」，目前无差别全算 |
+
+**结论**：stats 无法照搬（数据源是硬约束），但方案 A 的哲学等价于 stats——**让每次轮询尽可能廉价（缓存挡住重解析）+ 不显示的视图不计算（popover 可见性）**。再补一条 stats 启发：**接系统电源通知，睡眠时停轮询**。
+
+## 4. 方案选择
+
+| 方案 | 思路 | 收益 | 代价 | 结论 |
+|---|---|---|---|---|
+| **A+ 自适应（选定）** | 刷新绑 popover 可见性 + 轮询走缓存 | dormant 期 CPU 归零，体验无损 | 改造中等，风险可控 | ✅ |
+| B 事件驱动 | FSEvents 监听日志变化，有新数据才解析 | 理论最省 | daemon 需增量解析、文件监听坑多、风险高 | 未来演进 |
+| C 纯降频 | 只调常量 5s→30s | 改动最小 | 治标不治本，体验变迟钝 | ❌ |
+
+**选定方案 A+**：精准命中「CPU 明显 + badge/popover 两者都高频」场景——不看时 CPU 归零，看时全速无损。不堵死未来演进到 B 的路。
+
+## 5. 详细设计
+
+### 5.1 刷新模式状态机
+
+`BadgeUpdater` 引入显式模式：
+
+```swift
+enum RefreshMode { case dormant, active, suspended }
+private var mode: RefreshMode = .dormant
+```
+
+| 模式 | 触发 | 行为 |
+|---|---|---|
+| `.dormant` | popover 合上（默认） | 60s 周期，只跑 `updateBadge()`（refresh:false 走缓存）。**不**算 hourly/projects/trend、**不**拉 quota、**不**脉冲采样 |
+| `.active` | popover 打开（`NSPopover.willShow`） | 立即 `updateFull()`（refresh:true 拿新鲜）；随后每 **10s** `samplePulse()`（refresh:true 算速率 delta）+ 每 **60s** `updateFull()`（refresh:false 走缓存，刷新 hourly/projects/trend/quota 详情视图） |
+| `.suspended` | 系统睡眠 / 进入低电量模式 | 停主 timer，仅保留 `DaemonManager` 30s healthCheck（廉价） |
+
+切换由 AppDelegate 驱动：
+- `NSPopover.willShow` → `setMode(.active)`
+- `NSPopover.willClose` → `setMode(.dormant)`
+- `NSWorkspace.willSleepNotification` → `setMode(.suspended)`
+- `NSWorkspace.didWakeNotification` → 恢复睡眠前的模式（dormant 或 active）
+- `NSProcessInfoPowerStateDidChange` / `isLowPowerModeEnabled` → low-power 时降级 dormant 周期到 120s
+
+### 5.2 轮询瘦身（让每次轮询廉价）
+
+将 `update()` 拆为两个口径：
+
+- **`updateBadge()`（轻）**：仅 `getDaily(refresh:false)` → 聚合今日 total/cost → 更新 `badgeImage`/`tooltipText`/`todaySummary`。不算 hourly/projects/trend、不拉 quota。
+- **`updateFull()`（重）**：在 `updateBadge` 基础上 + `getBlocks` + `getProjects` + `getQuota`（**均 refresh:false，走 daemon 缓存**）+ 计算 hourly/projects/models/trend。
+
+Quota 策略：
+- badge / dormant 周期：**完全不拉 quota**。
+- `updateFull()`：`refresh:false` 命中 daemon 的 60s `QuotaCache`（`src/server/quota/cache.ts`），**不再每周期强刷外部 API**。
+- 强刷只在用户手动点「刷新按钮」时：`refreshNow()` 改为调用 `updateFull()` 并带 `refresh:true`（清缓存拿最新）。
+
+脉冲采样：
+- 仅 `.active` 模式运行，频率 **10s**（原 5s）。
+- `samplePulse()` 保持 `refresh:true`——因为速率 delta 需要相对新鲜的今日累计值，走 5min 缓存会让连续两次采样拿到同值导致速率恒为 0。
+- 权衡：active 期每 10s 重解析一次（用户在看，可接受，且比原 5s 省一半）；dormant 期完全不采样（CPU 归零的关键）。
+
+**active 期详情视图刷新**：脉冲只调 `getDaily`，不刷新 hourly/projects/trend/quota。为让这些详情视图在 popover 打开期间也保持新鲜，active 模式额外每 60s 跑一次 `updateFull(refresh:false)`——走 daemon 缓存，**不触发重解析**（5min 内命中缓存），Swift 端只是周期性轻量计算 + UI 更新，daemon CPU 几乎不增。
+
+### 5.3 daemon 端配合（缓存挡住重解析）
+
+Swift 端默认改 `refresh:false` 后，daemon 现有缓存即可生效：
+- usage 缓存：`src/server/cache.ts`，`DEFAULT_TTL = 5min`（内存 + 磁盘 stale-while-revalidate）。
+- quota 缓存：`src/server/quota/cache.ts`，`ttlMs = 60s`。
+
+**效果**：「扫盘解析 JSONL」的频率从**每 5s → 每 5min**（仅当 dormant 周期命中缓存过期那次 daemon 才真正解析）。这是 dormant 期 CPU 归零的核心来源。
+
+**daemon 基本无需改动**（缓存机制已存在），改动主要在 Swift 端调整 `refresh` 参数与 `tick` 分支。
+
+### 5.4 可靠性 / 错误处理
+
+- daemon 崩溃 / 被回收 → `DaemonManager` 30s healthCheck 自愈 + `BadgeUpdater.updatePort` 热切换端口（已有机制，见 cerebrum 2026-06-19 条目）。模式状态在端口热切换时保持。
+- popover 打开瞬间数据 stale → 走现有 stale-while-revalidate，先显示旧数据，后台 revalidate 后刷新。
+- 模式切换幂等：重复 `setMode(.active)` 不会叠加多个脉冲 timer。
+
+### 5.5 测试策略
+
+- **单元（Swift）**：
+  - `BadgeUpdater` 模式切换：mock popover 可见性，断言 dormant 不触发 blocks/projects/quota 请求（用 mock APIClient 计数）。
+  - dormant 周期 60s、active 脉冲 10s 的计时正确性。
+- **单元（daemon，已有）**：扩展 `src/__tests__/server/cache.test.ts`，验证 `refresh:false` 命中 5min 缓存、`refresh:true` 绕过。
+- **手动验收**：活动监视器观察 popover 合上 5min 后 TokenDash + daemon 的 CPU 是否降到接近 0。
+
+## 6. 关键决策记录
+
+| 决策 | 选择 | 理由 |
+|---|---|---|
+| dormant badge 周期 | 60s | badge 瞄一眼无需更实时；可后续做成用户可调 |
+| 脉冲采样频率（active） | 10s | 用户拍板：图够细腻，CPU 较 5s 减半 |
+| 脉冲是否走缓存 | 否（refresh:true） | 速率 delta 需新鲜值，走缓存会让速率恒为 0 |
+| quota 拉取 | 周期走 60s 缓存，仅手动刷新强刷 | 消除每周期外部 API 调用 |
+| 系统电源感知 | 接入 | stats 启发；睡眠/低电量停轮询 |
+
+## 7. 范围
+
+**In scope**：
+- `BadgeUpdater`：模式状态机 + `update()` 拆分 + refresh 参数调整 + 脉冲仅在 active。
+- AppDelegate：popover 开闭 + 系统电源通知 hook，驱动 `setMode`。
+- quota 走缓存、手动刷新强刷。
+- 手动验收 + 单测扩展。
+
+**Out of scope（未来演进）**：
+- 方案 B：FSEvents 事件驱动 + daemon 增量解析。
+- 把 daemon 的 TS 解析逻辑迁移到 Swift 原生（消除 Node 进程）。
+- 浏览器 dashboard 版的能耗。
+
+## 8. 验收标准
+
+1. popover 合上 ≥5min 后，活动监视器中 TokenDash + tokendash daemon 的平均 CPU 接近 0（< 0.5%）。
+2. dormant 期 badge 仍每 60s 更新今日 token 数（缓存值）。
+3. popover 打开 → 1s 内全量数据可见；实时速率图每 10s 刷新一次。
+4. 系统睡眠 → 主轮询停止；唤醒 → 自动恢复。
+5. 无功能回归：badge 显示、quota 卡片、dashboard 按钮、daemon 崩溃自愈均正常。
+
+## 9. 风险
+
+- **NSPopover 通知可靠性**：项目已用 NSStatusItem + NSPopover（非 MenuBarExtra，见 cerebrum 2026-06-11）。需确认现有 AppDelegate 能稳定接收 `willShow/willClose`；若不可靠，回退用 popover delegate (`popoverDidShow`/`popoverDidClose`)。
+- **active 期仍每 10s 解析**：会话文件极大时 active CPU 仍不低，但仅限用户主动查看期间，可接受；若需进一步优化，触发方案 B。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zhangferry-dev/tokendash",
-  "version": "1.7.5",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zhangferry-dev/tokendash",
-      "version": "1.7.5",
+      "version": "1.8.0",
       "dependencies": {
         "express": "^5.1.0",
         "open": "^10.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhangferry-dev/tokendash",
-  "version": "1.7.5",
+  "version": "1.8.0",
   "type": "module",
   "description": "Token Usage Analytics Dashboard",
   "publishConfig": {

--- a/src/server/daemon.ts
+++ b/src/server/daemon.ts
@@ -133,7 +133,47 @@ async function main() {
   writePidFile();
   writePortFile(port);
 
-  // Warm up cache: pre-parse JSONL for all agents so first Swift fetch is fast
+  // Graceful shutdown — defined early so the orphan watcher below can call it.
+  const shutdown = () => {
+    cleanupFiles();
+    server.close(() => process.exit(0));
+    // Force exit after 5s if server.close hangs
+    setTimeout(() => process.exit(0), 5000);
+  };
+
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+  process.on('uncaughtException', (err) => {
+    console.error('[tokendash-daemon] uncaught:', err);
+    shutdown();
+  });
+
+  // Orphan prevention: the Swift app owns this daemon's lifecycle. Arm the
+  // watcher BEFORE warm-up so a slow first JSONL parse can't leave a window
+  // where the daemon outlives a crashing app. If the app dies without SIGTERM
+  // (crash, SIGKILL, `pkill -x TokenDash`, system-shutdown race), this process
+  // would be reparented to launchd and keep holding the port — forcing future
+  // launches onto fallback ports and accumulating zombies. Detect parent death
+  // (reparent to pid 1, or original parent pid no longer alive) and exit.
+  const parentPid = process.ppid;
+  if (parentPid && parentPid > 1) {
+    const orphanTimer = setInterval(() => {
+      let parentGone = false;
+      if (process.ppid === 1) parentGone = true;
+      else {
+        try { process.kill(parentPid, 0); }
+        catch { parentGone = true; }
+      }
+      if (parentGone) {
+        clearInterval(orphanTimer);
+        console.error('[tokendash-daemon] parent app gone, exiting to avoid orphan');
+        shutdown();
+      }
+    }, 5000);
+  }
+
+  // Warm up cache: pre-parse JSONL for all agents so first Swift fetch is fast.
+  // Best-effort — armed AFTER the watchers above so a slow parse can't delay them.
   try {
     const agentsRes = await new Promise<any>((resolve, reject) => {
       http.get(`http://${TOKEN_DASH_HOST}:${port}/api/agents`, (res) => {
@@ -151,21 +191,6 @@ async function main() {
   } catch (_) {
     // Warm-up is best-effort; don't block startup
   }
-
-  // Graceful shutdown
-  const shutdown = () => {
-    cleanupFiles();
-    server.close(() => process.exit(0));
-    // Force exit after 5s if server.close hangs
-    setTimeout(() => process.exit(0), 5000);
-  };
-
-  process.on('SIGTERM', shutdown);
-  process.on('SIGINT', shutdown);
-  process.on('uncaughtException', (err) => {
-    console.error('[tokendash-daemon] uncaught:', err);
-    shutdown();
-  });
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
## v1.8.0 — Energy optimization + reliability

Cuts menu-bar CPU dramatically and fixes daemon lifecycle bugs that caused empty popovers and orphan processes.

### ⚡ Energy
- **Refresh state machine** (`a08f48f`): dormant / active / suspended — popover-closed CPU drops to ~0 (cache-served badge only); full-speed refresh only when the popover is open; suspended on system sleep / low-power mode.
- **Pulse tab + 10s sampler hidden** (`1766e61`): the experimental real-time rate chart was a top CPU draw; gated behind `pulseEnabled = false`, code retained for a later return.

### 🔧 Reliability
- **No more orphan daemons** (`73a304b`, `1b0b6e2`): the node daemon now exits when its parent app dies (parent-death watcher), and the health check no longer restarts during daemon warm-up. Fixes the duplicate daemons that stacked across ports 3456-3463 and starved the popover of data.
- **Popover never opens empty** (`31d0f99`): prime detail state on launch, paint today/hourly/projects before the slower quota fetch, and fall back to the previous view (stale-while-revalidate) when today data isn't ready.
- **Smoother pulse curve** (`0202793`): trailing 30s rate window (code retained while pulse is hidden).

### ✅ Verification
- 12/12 Swift tests pass (3 BadgeUpdater mode + 4 pulse metrics + 5 smoothed-rates).
- popover-closed CPU 0.0% across 3 samples; daemon stays singleton across a 35s health-check window; `pkill -x TokenDash` → daemon exits within ~5s.

### 🚀 Release
After merge: `npm run deploy:check` then `npm run deploy` (requires clean main, HEAD = origin/main, Sparkle keychain ACL persisted — see `.wolf/cerebrum.md` bug-037).

🤖 Generated with [Claude Code](https://claude.com/claude-code)