### PR TITLE
Guard Sparkle build numbers against regressions

### DIFF
--- a/docs/updating.md
+++ b/docs/updating.md
@@ -92,9 +92,11 @@ matching public key.
 
 ## Notes
 
-- `CFBundleVersion` must be an incrementing integer. It's derived from
-  `git rev-list --count HEAD`, so each commit that gets packaged bumps it. Don't
-  set it manually.
+- `CFBundleVersion` must be an incrementing integer. Packaging starts from
+  `BUILD_NUMBER` or `git rev-list --count HEAD`, then raises it above the
+  highest `sparkle:version` found in the latest and recent published appcasts.
+  The deploy flow runs this check in strict mode so a release cannot ship when
+  prior appcasts cannot be inspected.
 - If `SUPublicEDKey` is empty (keys not generated), `package-app.sh` warns and
   the build runs but installed copies will **reject** updates until a key is set.
 - The distributed macOS app is ad-hoc signed and is not notarized. First-time

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -86,7 +86,7 @@ npm run test:e2e
 step "Building npm package, macOS app, and DMG"
 rm -f "$APPCAST"
 npm pack --dry-run >/dev/null
-npm run build:dmg
+SPARKLE_BUILD_STRICT=1 npm run build:dmg
 [ -s "$DMG" ] || fail "DMG was not created: $DMG"
 
 step "Generating signed Sparkle appcast"

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -73,7 +73,7 @@ fi
 # Resolve version + Sparkle config for Info.plist.
 # CFBundleVersion MUST be an incrementing integer (Sparkle compares these).
 APP_VERSION=$(node -p "require('$REPO_ROOT/package.json').version" 2>/dev/null || echo "2.0.0")
-BUILD_NUMBER="${BUILD_NUMBER:-$(git -C "$REPO_ROOT" rev-list --count HEAD 2>/dev/null || echo "1")}"
+BUILD_NUMBER="$("$REPO_ROOT/scripts/resolve-sparkle-build-number.sh")"
 SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-https://github.com/zhangferry/tokendash/releases/latest/download/appcast.xml}"
 # EdDSA public key: from env, or ~/.tokendash/eddsa_pub.key, or empty (warn).
 SPARKLE_EDDSA_PUB="${SPARKLE_EDDSA_PUB:-}"

--- a/scripts/resolve-sparkle-build-number.sh
+++ b/scripts/resolve-sparkle-build-number.sh
@@ -91,6 +91,9 @@ process.stdout.write(uniqueUrls.join("\n") + (uniqueUrls.length ? "\n" : ""));
 REMOTE_VERSIONS=()
 FETCHED_ANY=0
 FETCHED_RECENT_RELEASES=0
+RECENT_APPCAST_URL_COUNT=0
+RECENT_APPCAST_SUCCESS_COUNT=0
+RECENT_APPCAST_FAILURE_COUNT=0
 
 add_versions_from_url() {
     local url="$1"
@@ -99,15 +102,25 @@ add_versions_from_url() {
         echo "Warning: unable to fetch Sparkle appcast: $url" >&2
         return 1
     fi
-    FETCHED_ANY=1
     versions="$(printf '%s' "$xml" | extract_versions || true)"
     if [ -z "$versions" ]; then
         echo "Warning: Sparkle appcast has no sparkle:version values: $url" >&2
         return 1
     fi
+    FETCHED_ANY=1
     while IFS= read -r version; do
         [ -n "$version" ] && REMOTE_VERSIONS+=("$version")
     done <<< "$versions"
+}
+
+add_recent_versions_from_url() {
+    local url="$1"
+    RECENT_APPCAST_URL_COUNT=$((RECENT_APPCAST_URL_COUNT + 1))
+    if add_versions_from_url "$url"; then
+        RECENT_APPCAST_SUCCESS_COUNT=$((RECENT_APPCAST_SUCCESS_COUNT + 1))
+    else
+        RECENT_APPCAST_FAILURE_COUNT=$((RECENT_APPCAST_FAILURE_COUNT + 1))
+    fi
 }
 
 # Always inspect the configured feed first. In production this is GitHub's
@@ -120,15 +133,18 @@ add_versions_from_url "$FEED_URL" || true
 if [ -n "${SPARKLE_APPCAST_URLS:-}" ]; then
     FETCHED_RECENT_RELEASES=1
     while IFS= read -r url; do
-        [ -n "$url" ] && add_versions_from_url "$url" || true
+        [ -n "$url" ] && add_recent_versions_from_url "$url"
     done <<< "$SPARKLE_APPCAST_URLS"
 else
     if releases_json="$(fetch_releases_json 2>/dev/null)"; then
         FETCHED_RECENT_RELEASES=1
         urls="$(printf '%s' "$releases_json" | extract_appcast_urls || true)"
         while IFS= read -r url; do
-            [ -n "$url" ] && add_versions_from_url "$url" || true
+            [ -n "$url" ] && add_recent_versions_from_url "$url"
         done <<< "$urls"
+        if [ "$RECENT_APPCAST_URL_COUNT" -eq 0 ]; then
+            echo "Warning: recent GitHub Releases did not include appcast.xml assets for $REPO" >&2
+        fi
     else
         echo "Warning: unable to fetch recent GitHub Releases for $REPO" >&2
     fi
@@ -141,6 +157,14 @@ if [ "$STRICT" = "1" ]; then
     fi
     if [ "$FETCHED_RECENT_RELEASES" -ne 1 ]; then
         echo "Error: unable to inspect recent GitHub Release appcasts; refusing release build." >&2
+        exit 1
+    fi
+    if [ "$RECENT_APPCAST_URL_COUNT" -eq 0 ]; then
+        echo "Error: no recent GitHub Release appcasts were available to inspect; refusing release build." >&2
+        exit 1
+    fi
+    if [ "$RECENT_APPCAST_FAILURE_COUNT" -ne 0 ]; then
+        echo "Error: unable to inspect all recent GitHub Release appcasts; refusing release build." >&2
         exit 1
     fi
 fi

--- a/scripts/resolve-sparkle-build-number.sh
+++ b/scripts/resolve-sparkle-build-number.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Resolve the CFBundleVersion/Sparkle build number for a packaged release.
+#
+# Sparkle compares the monotonically increasing build number
+# (CFBundleVersion / sparkle:version), not just the human-facing semver. A
+# shallow checkout or explicit BUILD_NUMBER can accidentally move this number
+# backwards, making Sparkle detect a newer shortVersionString but refuse to
+# install it. This helper keeps the local build number above recently published
+# appcasts while still allowing offline/local builds to fall back to git count.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO="${GITHUB_REPO:-zhangferry/tokendash}"
+FEED_URL="${SPARKLE_FEED_URL:-https://github.com/${REPO}/releases/latest/download/appcast.xml}"
+LOOKBACK="${SPARKLE_RELEASE_LOOKBACK:-10}"
+STRICT="${SPARKLE_BUILD_STRICT:-0}"
+CURL_BIN="${CURL_BIN:-curl}"
+GH_BIN="${GH_BIN:-gh}"
+
+if [ -n "${BUILD_NUMBER:-}" ]; then
+    LOCAL_BUILD="$BUILD_NUMBER"
+else
+    LOCAL_BUILD="$(git -C "$REPO_ROOT" rev-list --count HEAD 2>/dev/null || echo "1")"
+fi
+
+if ! [[ "$LOCAL_BUILD" =~ ^[0-9]+$ ]]; then
+    echo "Error: BUILD_NUMBER must be an integer, got: $LOCAL_BUILD" >&2
+    exit 1
+fi
+
+if ! [[ "$LOOKBACK" =~ ^[0-9]+$ ]] || [ "$LOOKBACK" -lt 1 ]; then
+    echo "Error: SPARKLE_RELEASE_LOOKBACK must be a positive integer, got: $LOOKBACK" >&2
+    exit 1
+fi
+
+fetch_url() {
+    local url="$1"
+    "$CURL_BIN" -LfsS \
+        -H "Accept: application/vnd.github+json, application/xml, text/xml;q=0.9, */*;q=0.8" \
+        -H "User-Agent: TokenDash-release" \
+        "$url"
+}
+
+fetch_releases_json() {
+    local api_path="repos/${REPO}/releases?per_page=${LOOKBACK}"
+    local api_url="${GITHUB_RELEASES_API_URL:-https://api.github.com/${api_path}}"
+
+    if [ -z "${GITHUB_RELEASES_API_URL:-}" ] \
+        && command -v "$GH_BIN" >/dev/null 2>&1 \
+        && "$GH_BIN" auth status >/dev/null 2>&1; then
+        "$GH_BIN" api "$api_path"
+        return
+    fi
+
+    fetch_url "$api_url"
+}
+
+extract_versions() {
+    node -e '''
+const fs = require("node:fs");
+const input = fs.readFileSync(0, "utf8");
+const versions = [];
+for (const match of input.matchAll(/<(?:[A-Za-z0-9_-]+:)?version\b[^>]*>\s*(\d+)\s*<\/(?:[A-Za-z0-9_-]+:)?version>/g)) {
+  versions.push(match[1]);
+}
+process.stdout.write(versions.join("\n") + (versions.length ? "\n" : ""));
+'''
+}
+extract_appcast_urls() {
+    node -e '''
+const fs = require("node:fs");
+let releases;
+try {
+  releases = JSON.parse(fs.readFileSync(0, "utf8"));
+} catch {
+  process.exit(0);
+}
+if (!Array.isArray(releases)) process.exit(0);
+const urls = [];
+for (const release of releases) {
+  for (const asset of release.assets || []) {
+    if (asset && asset.name === "appcast.xml" && asset.browser_download_url) {
+      urls.push(asset.browser_download_url);
+    }
+  }
+}
+const uniqueUrls = [...new Set(urls)];
+process.stdout.write(uniqueUrls.join("\n") + (uniqueUrls.length ? "\n" : ""));
+'''
+}
+REMOTE_VERSIONS=()
+FETCHED_ANY=0
+FETCHED_RECENT_RELEASES=0
+
+add_versions_from_url() {
+    local url="$1"
+    local xml versions
+    if ! xml="$(fetch_url "$url" 2>/dev/null)"; then
+        echo "Warning: unable to fetch Sparkle appcast: $url" >&2
+        return 1
+    fi
+    FETCHED_ANY=1
+    versions="$(printf '%s' "$xml" | extract_versions || true)"
+    if [ -z "$versions" ]; then
+        echo "Warning: Sparkle appcast has no sparkle:version values: $url" >&2
+        return 1
+    fi
+    while IFS= read -r version; do
+        [ -n "$version" ] && REMOTE_VERSIONS+=("$version")
+    done <<< "$versions"
+}
+
+# Always inspect the configured feed first. In production this is GitHub's
+# releases/latest appcast; in tests it can be a controlled fixture URL.
+add_versions_from_url "$FEED_URL" || true
+
+# Inspect recent release appcasts too, not just releases/latest. This catches a
+# bad latest appcast whose build number already regressed below the prior
+# release (for example 1.8.2 build 87 after 1.8.1 build 106).
+if [ -n "${SPARKLE_APPCAST_URLS:-}" ]; then
+    FETCHED_RECENT_RELEASES=1
+    while IFS= read -r url; do
+        [ -n "$url" ] && add_versions_from_url "$url" || true
+    done <<< "$SPARKLE_APPCAST_URLS"
+else
+    if releases_json="$(fetch_releases_json 2>/dev/null)"; then
+        FETCHED_RECENT_RELEASES=1
+        urls="$(printf '%s' "$releases_json" | extract_appcast_urls || true)"
+        while IFS= read -r url; do
+            [ -n "$url" ] && add_versions_from_url "$url" || true
+        done <<< "$urls"
+    else
+        echo "Warning: unable to fetch recent GitHub Releases for $REPO" >&2
+    fi
+fi
+
+if [ "$STRICT" = "1" ]; then
+    if [ "$FETCHED_ANY" -ne 1 ]; then
+        echo "Error: unable to fetch any published Sparkle appcast; refusing release build." >&2
+        exit 1
+    fi
+    if [ "$FETCHED_RECENT_RELEASES" -ne 1 ]; then
+        echo "Error: unable to inspect recent GitHub Release appcasts; refusing release build." >&2
+        exit 1
+    fi
+fi
+
+MAX_REMOTE=0
+for version in ${REMOTE_VERSIONS[@]+"${REMOTE_VERSIONS[@]}"}; do
+    if [[ "$version" =~ ^[0-9]+$ ]] && [ "$version" -gt "$MAX_REMOTE" ]; then
+        MAX_REMOTE="$version"
+    fi
+done
+
+MIN_NEXT=$((MAX_REMOTE + 1))
+if [ "$LOCAL_BUILD" -lt "$MIN_NEXT" ]; then
+    echo "Info: raising Sparkle build number from $LOCAL_BUILD to $MIN_NEXT (latest published max: $MAX_REMOTE)." >&2
+    echo "$MIN_NEXT"
+else
+    echo "$LOCAL_BUILD"
+fi

--- a/src/__tests__/server/nativeAppPackaging.test.ts
+++ b/src/__tests__/server/nativeAppPackaging.test.ts
@@ -148,6 +148,58 @@ XML
     expect(resolved).toBe('118');
   });
 
+  it('fails strict release builds when recent appcasts cannot be inspected', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'tokendash-appcast-'));
+    const curlStub = join(tempDir, 'curl');
+    writeFileSync(curlStub, `#!/bin/bash
+url="\${@: -1}"
+case "$url" in
+  *releases/latest/download/appcast.xml)
+    cat <<'XML'
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel><item><sparkle:version>87</sparkle:version></item></channel>
+</rss>
+XML
+    ;;
+  *api.github.com*)
+    cat <<'JSON'
+[
+  {"assets":[{"name":"appcast.xml","browser_download_url":"https://example.com/v1.8.1/appcast.xml"}]}
+]
+JSON
+    ;;
+  *v1.8.1*)
+    exit 22
+    ;;
+esac
+`, { mode: 0o755 });
+
+    let error: unknown;
+    try {
+      execFileSync('bash', ['scripts/resolve-sparkle-build-number.sh'], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          BUILD_NUMBER: '87',
+          CURL_BIN: curlStub,
+          GH_BIN: join(tempDir, 'missing-gh'),
+          SPARKLE_BUILD_STRICT: '1',
+          SPARKLE_APPCAST_URLS: '',
+          SPARKLE_FEED_URL: '',
+          GITHUB_RELEASES_API_URL: '',
+        },
+        encoding: 'utf8',
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toMatchObject({ status: 1 });
+    expect(String((error as { stderr?: Buffer })?.stderr)).toContain(
+      'unable to inspect all recent GitHub Release appcasts'
+    );
+  });
+
   it('forces native menu bar refreshes past server-side caches', () => {
     const apiClient = readFileSync('TokenDashSwift/Sources/TokenDash/Services/APIClient.swift', 'utf8');
     const badgeUpdater = readFileSync('TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift', 'utf8');

--- a/src/__tests__/server/nativeAppPackaging.test.ts
+++ b/src/__tests__/server/nativeAppPackaging.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 describe('native app packaging resources', () => {
   it('keeps the menu bar badge as a compact adaptive template image', () => {
@@ -39,6 +42,110 @@ describe('native app packaging resources', () => {
     expect(packageApp).toContain('XPCServices/Downloader.xpc');
     expect(packageApp).toContain('--preserve-metadata=entitlements');
     expect(packageApp).toContain('Updater.app');
+  });
+
+  it('bumps Sparkle build numbers past the latest published appcast', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'tokendash-appcast-'));
+    const curlStub = join(tempDir, 'curl');
+    writeFileSync(curlStub, `#!/bin/sh
+cat <<'XML'
+<?xml version="1.0" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <sparkle:version>106</sparkle:version>
+      <sparkle:shortVersionString>1.8.1</sparkle:shortVersionString>
+    </item>
+  </channel>
+</rss>
+XML
+`, { mode: 0o755 });
+
+    const resolved = execFileSync('bash', ['scripts/resolve-sparkle-build-number.sh'], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        BUILD_NUMBER: '87',
+        CURL_BIN: curlStub,
+        GH_BIN: join(tempDir, 'missing-gh'),
+      },
+      encoding: 'utf8',
+    }).trim();
+
+    expect(resolved).toBe('107');
+  });
+
+  it('uses recent release appcasts when the latest appcast build number regressed', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'tokendash-appcast-'));
+    const curlStub = join(tempDir, 'curl');
+    writeFileSync(curlStub, `#!/bin/bash
+url="\${@: -1}"
+case "$url" in
+  *releases/latest/download/appcast.xml)
+    cat <<'XML'
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel><item><sparkle:version>87</sparkle:version></item></channel>
+</rss>
+XML
+    ;;
+  *api.github.com*)
+    cat <<'JSON'
+[
+  {"assets":[{"name":"appcast.xml","browser_download_url":"https://example.com/v1.8.2/appcast.xml"}]},
+  {"assets":[{"name":"appcast.xml","browser_download_url":"https://example.com/v1.8.1/appcast.xml"}]}
+]
+JSON
+    ;;
+  *v1.8.2*)
+    cat <<'XML'
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel><item><sparkle:version>87</sparkle:version></item></channel></rss>
+XML
+    ;;
+  *v1.8.1*)
+    cat <<'XML'
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel><item><sparkle:version>106</sparkle:version></item></channel></rss>
+XML
+    ;;
+esac
+`, { mode: 0o755 });
+
+    const resolved = execFileSync('bash', ['scripts/resolve-sparkle-build-number.sh'], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        BUILD_NUMBER: '87',
+        CURL_BIN: curlStub,
+        GH_BIN: join(tempDir, 'missing-gh'),
+      },
+      encoding: 'utf8',
+    }).trim();
+
+    expect(resolved).toBe('107');
+  });
+
+  it('keeps a higher local Sparkle build number when the published appcast is older', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'tokendash-appcast-'));
+    const curlStub = join(tempDir, 'curl');
+    writeFileSync(curlStub, `#!/bin/sh
+cat <<'XML'
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel><item><sparkle:version>106</sparkle:version></item></channel>
+</rss>
+XML
+`, { mode: 0o755 });
+
+    const resolved = execFileSync('bash', ['scripts/resolve-sparkle-build-number.sh'], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        BUILD_NUMBER: '118',
+        CURL_BIN: curlStub,
+        GH_BIN: join(tempDir, 'missing-gh'),
+      },
+      encoding: 'utf8',
+    }).trim();
+
+    expect(resolved).toBe('118');
   });
 
   it('forces native menu bar refreshes past server-side caches', () => {


### PR DESCRIPTION
## Summary
- resolve packaged CFBundleVersion from the local build number plus latest/recent published Sparkle appcasts
- fail deploy packaging in strict mode when prior appcasts cannot be inspected
- cover the 1.8.1 build 106 -> 1.8.2 build 87 regression case with packaging tests

## Verification
- npx vitest run src/__tests__/server/nativeAppPackaging.test.ts
- npm run typecheck
- npm test
- npm run build
- BUILD_NUMBER=87 ./scripts/resolve-sparkle-build-number.sh

## Notes
- Did not run npm run deploy:check because it performs full DMG packaging/signing and Playwright e2e; the changed guard is covered by unit tests and direct script execution.