### PR TITLE
Fix Codex quota display and release monotonicity guards

### DIFF
--- a/docs/updating.md
+++ b/docs/updating.md
@@ -97,6 +97,9 @@ matching public key.
   highest `sparkle:version` found in the latest and recent published appcasts.
   The deploy flow runs this check in strict mode so a release cannot ship when
   prior appcasts cannot be inspected.
+- `package.json`'s semver must also move forward. `deploy.sh` refuses versions
+  that are less than or equal to the latest published npm package, GitHub
+  Release, or remote release tag.
 - If `SUPublicEDKey` is empty (keys not generated), `package-app.sh` warns and
   the build runs but installed copies will **reject** updates until a key is set.
 - The distributed macOS app is ad-hoc signed and is not notarized. First-time

--- a/scripts/assert-release-version-advances.sh
+++ b/scripts/assert-release-version-advances.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Fail a release when package.json's semver does not advance past already
+# published npm/GitHub/tag versions. Sparkle needs both the human version and
+# CFBundleVersion to move forward; build-number monotonicity alone is not
+# enough.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION="${1:-$(node -p "require('$REPO_ROOT/package.json').version")}"
+PACKAGE_NAME="${PACKAGE_NAME:-@zhangferry-dev/tokendash}"
+REGISTRY="${REGISTRY:-https://registry.npmjs.org}"
+REPO="${GITHUB_REPO:-zhangferry/tokendash}"
+NPM_BIN="${NPM_BIN:-npm}"
+GH_BIN="${GH_BIN:-gh}"
+GIT_BIN="${GIT_BIN:-git}"
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: release version must be semver x.y.z, got: $VERSION" >&2
+    exit 1
+fi
+
+REFERENCES="${RELEASE_VERSION_REFERENCES:-}"
+
+if [ -z "$REFERENCES" ]; then
+    if npm_version="$("$NPM_BIN" view "$PACKAGE_NAME" version --registry "$REGISTRY" 2>/dev/null)"; then
+        REFERENCES+="${npm_version}"$'\n'
+    else
+        echo "Warning: unable to inspect latest npm version for $PACKAGE_NAME" >&2
+    fi
+
+    if gh_version="$("$GH_BIN" release view --repo "$REPO" --json tagName --jq '.tagName' 2>/dev/null)"; then
+        REFERENCES+="${gh_version}"$'\n'
+    else
+        echo "Warning: unable to inspect latest GitHub Release for $REPO" >&2
+    fi
+
+    if tag_versions="$("$GIT_BIN" ls-remote --tags origin 'refs/tags/v[0-9]*' 2>/dev/null | sed -E 's#.*refs/tags/v?([^{}]+)(\\^\\{\\})?$#\\1#')"; then
+        REFERENCES+="${tag_versions}"$'\n'
+    else
+        echo "Warning: unable to inspect remote release tags" >&2
+    fi
+fi
+
+REFERENCES="$REFERENCES" node - "$VERSION" <<'NODE'
+const current = parse(process.argv[2]);
+const refs = (process.env.REFERENCES || '')
+  .split(/\s+/)
+  .map((value) => value.replace(/^v/, ''))
+  .map(parse)
+  .filter(Boolean);
+
+if (!current) {
+  console.error(`Error: release version must be semver x.y.z, got: ${process.argv[2]}`);
+  process.exit(1);
+}
+
+if (refs.length === 0) {
+  console.error('Error: no published release versions could be inspected; refusing release.');
+  process.exit(1);
+}
+
+const latest = refs.reduce((max, version) => compare(version, max) > 0 ? version : max, refs[0]);
+if (compare(current, latest) <= 0) {
+  console.error(`Error: release version ${format(current)} must be greater than latest published ${format(latest)}.`);
+  process.exit(1);
+}
+
+function parse(value) {
+  const match = String(value || '').trim().match(/^(\d+)\.(\d+)\.(\d+)$/);
+  return match ? match.slice(1).map(Number) : null;
+}
+
+function compare(a, b) {
+  for (let i = 0; i < 3; i += 1) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+function format(version) {
+  return version.join('.');
+}
+NODE

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -69,6 +69,7 @@ fi
 if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
     fail "GitHub Release $TAG already exists"
 fi
+"$REPO_ROOT/scripts/assert-release-version-advances.sh" "$VERSION"
 
 if ! $DRY_RUN; then
     [ "$(git branch --show-current)" = "main" ] || fail "deploy must run from main"

--- a/src/__tests__/server/nativeAppPackaging.test.ts
+++ b/src/__tests__/server/nativeAppPackaging.test.ts
@@ -200,6 +200,38 @@ esac
     );
   });
 
+  it('refuses a release version that does not advance past published versions', () => {
+    let error: unknown;
+    try {
+      execFileSync('bash', ['scripts/assert-release-version-advances.sh', '1.8.2'], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          RELEASE_VERSION_REFERENCES: '1.8.2\nv1.8.1\n1.7.5',
+        },
+        encoding: 'utf8',
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toMatchObject({ status: 1 });
+    expect(String((error as { stderr?: Buffer })?.stderr)).toContain(
+      'release version 1.8.2 must be greater than latest published 1.8.2'
+    );
+  });
+
+  it('accepts a release version that advances past published versions', () => {
+    expect(() => execFileSync('bash', ['scripts/assert-release-version-advances.sh', '1.8.3'], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        RELEASE_VERSION_REFERENCES: '1.8.2\nv1.8.1\n1.7.5',
+      },
+      encoding: 'utf8',
+    })).not.toThrow();
+  });
+
   it('forces native menu bar refreshes past server-side caches', () => {
     const apiClient = readFileSync('TokenDashSwift/Sources/TokenDash/Services/APIClient.swift', 'utf8');
     const badgeUpdater = readFileSync('TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift', 'utf8');

--- a/src/__tests__/server/quotaAdapters.test.ts
+++ b/src/__tests__/server/quotaAdapters.test.ts
@@ -7,7 +7,7 @@ import {
   classifyHttpError,
   HttpError,
 } from '../../server/quota/helpers.js';
-import { resolveCodexBinary } from '../../server/quota/adapters/codex.js';
+import { normalizeCodexWindows, resolveCodexBinary } from '../../server/quota/adapters/codex.js';
 import {
   claudeKeychainServiceNames,
   extractClaudeAccessToken,
@@ -297,6 +297,55 @@ describe('Claude adapter credential detection', () => {
 });
 
 describe('Codex CLI discovery', () => {
+  it('drops Codex placeholder tiers while keeping the real weekly window', () => {
+    const windows = normalizeCodexWindows({
+      rateLimitsByLimitId: {
+        weekly: {
+          limitName: 'weekly',
+          primary: { usedPercent: 0 },
+          secondary: { usedPercent: 42, windowDurationMins: 10080, resetsAt: 1782015024 },
+        },
+      },
+    });
+
+    expect(windows.map((w) => [w.id, w.label, w.usedPercent, w.durationMins])).toEqual([
+      ['codex_weekly_secondary', 'Weekly · Weekly', 42, 10080],
+    ]);
+  });
+
+  it('keeps a future real Codex 5-hour window when the provider reports one', () => {
+    const windows = normalizeCodexWindows({
+      rateLimitsByLimitId: {
+        codex: {
+          limitName: 'codex',
+          primary: { usedPercent: 16, windowDurationMins: 300, resetsAt: 1781997024 },
+          secondary: { usedPercent: 42, windowDurationMins: 10080, resetsAt: 1782015024 },
+        },
+      },
+    });
+
+    expect(windows.map((w) => [w.id, w.label, w.usedPercent, w.durationMins])).toEqual([
+      ['codex_codex_primary', 'Codex · 5-Hour', 16, 300],
+      ['codex_codex_secondary', 'Codex · Weekly', 42, 10080],
+    ]);
+  });
+
+  it('keeps a zero-usage Codex weekly window when it has real reset metadata', () => {
+    const windows = normalizeCodexWindows({
+      rateLimitsByLimitId: {
+        codex: {
+          limitName: 'codex',
+          primary: { usedPercent: 0, windowDurationMins: 10080, resetsAt: 1782015024 },
+        },
+      },
+    });
+
+    expect(windows).toHaveLength(1);
+    expect(windows[0].usedPercent).toBe(0);
+    expect(windows[0].durationMins).toBe(10080);
+    expect(windows[0].resetsAt).toBeDefined();
+  });
+
   it('prefers the official Codex app binary when GUI PATH is minimal', () => {
     const executable = '/Applications/Codex.app/Contents/Resources/codex';
     const resolved = resolveCodexBinary({

--- a/src/server/quota/adapters/codex.ts
+++ b/src/server/quota/adapters/codex.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, accessSync, constants } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
-import type { QuotaSnapshot } from '../types.js';
+import type { QuotaSnapshot, QuotaWindow } from '../types.js';
 import type { QuotaAdapter } from '../adapter.js';
 import { QuotaError, baseSnapshot } from '../adapter.js';
 import { unixToIso, windowFromPercent } from '../helpers.js';
@@ -19,18 +19,20 @@ import { unixToIso, windowFromPercent } from '../helpers.js';
  * or the OS keyring; presence of auth.json is our cheap configured check.
  */
 
-interface CodexRateLimit {
+export interface CodexRateLimit {
   limitId?: string;
   limitName?: string | null;
   primary?: { usedPercent?: number; windowDurationMins?: number; resetsAt?: number } | null;
   secondary?: { usedPercent?: number; windowDurationMins?: number; resetsAt?: number } | null;
 }
 
-interface CodexRateLimitsResult {
+export interface CodexRateLimitsResult {
   rateLimits?: CodexRateLimit;
   rateLimitsByLimitId?: Record<string, CodexRateLimit>;
   planType?: string;
 }
+
+type CodexRateLimitTier = NonNullable<CodexRateLimit['primary']>;
 
 function codexHome(): string {
   return process.env.CODEX_HOME || join(homedir(), '.codex');
@@ -49,23 +51,7 @@ export const codexAdapter: QuotaAdapter = {
 
   async fetch(): Promise<QuotaSnapshot> {
     const result = await queryRateLimits();
-    const buckets = result.rateLimitsByLimitId ?? (result.rateLimits ? { primary: result.rateLimits } : {});
-    const windows = [];
-
-    for (const [key, bucket] of Object.entries(buckets)) {
-      if (bucket.primary) {
-        windows.push(windowFromPercent(`codex_${key}_primary`, labelForBucket(key, 'primary', bucket), bucket.primary.usedPercent ?? 0, {
-          durationMins: bucket.primary.windowDurationMins,
-          resetsAt: unixToIso(bucket.primary.resetsAt),
-        }));
-      }
-      if (bucket.secondary) {
-        windows.push(windowFromPercent(`codex_${key}_secondary`, labelForBucket(key, 'secondary', bucket), bucket.secondary.usedPercent ?? 0, {
-          durationMins: bucket.secondary.windowDurationMins,
-          resetsAt: unixToIso(bucket.secondary.resetsAt),
-        }));
-      }
-    }
+    const windows = normalizeCodexWindows(result);
 
     const snap = baseSnapshot('codex', 'OpenAI Codex', {
       planName: result.planType ? capitalize(result.planType) : undefined,
@@ -74,6 +60,52 @@ export const codexAdapter: QuotaAdapter = {
     return { ...snap, status: { state: 'ok' } };
   },
 };
+
+export function normalizeCodexWindows(result: CodexRateLimitsResult): QuotaWindow[] {
+  const buckets = result.rateLimitsByLimitId ?? (result.rateLimits ? { primary: result.rateLimits } : {});
+  const candidates = [];
+
+  for (const [key, bucket] of Object.entries(buckets)) {
+    if (bucket.primary) {
+      candidates.push(windowCandidate(key, 'primary', bucket, bucket.primary));
+    }
+    if (bucket.secondary) {
+      candidates.push(windowCandidate(key, 'secondary', bucket, bucket.secondary));
+    }
+  }
+
+  // Codex currently exposes only a weekly Coding Plan limit. Some app-server
+  // versions still return a compatibility/placeholder tier next to the real
+  // weekly tier; exposing it creates a duplicate "Wk" chip with 0% and no reset.
+  // Keep any real window (including a future 5h limit) and only drop empty
+  // placeholder tiers that carry no duration/reset metadata.
+  return candidates
+    .filter((candidate) => !isPlaceholderTier(candidate.tier))
+    .map((candidate) => candidate.window);
+}
+
+function windowCandidate(
+  key: string,
+  tierName: 'primary' | 'secondary',
+  bucket: CodexRateLimit,
+  tier: CodexRateLimitTier,
+) {
+  return {
+    key,
+    bucket,
+    tier,
+    window: windowFromPercent(`codex_${key}_${tierName}`, labelForBucket(key, tierName, bucket), tier.usedPercent ?? 0, {
+      durationMins: tier.windowDurationMins,
+      resetsAt: unixToIso(tier.resetsAt),
+    }),
+  };
+}
+
+function isPlaceholderTier(tier: CodexRateLimitTier): boolean {
+  return (tier.usedPercent ?? 0) === 0
+    && !tier.windowDurationMins
+    && !tier.resetsAt;
+}
 
 function labelForBucket(key: string, tier: 'primary' | 'secondary', bucket: CodexRateLimit): string {
   const dur = tier === 'primary' ? bucket.primary?.windowDurationMins : bucket.secondary?.windowDurationMins;


### PR DESCRIPTION
## Summary
- normalize Codex Coding Plan windows by dropping only empty placeholder tiers, while keeping real weekly and future 5-hour windows
- add a deploy preflight that requires package.json semver to advance past published npm/GitHub/tag versions
- keep Sparkle build number guard as the CFBundleVersion monotonicity check, with strict appcast inspection as a supporting fail-safe

## Verification
- npx vitest run src/__tests__/server/quotaAdapters.test.ts
- npx vitest run src/__tests__/server/nativeAppPackaging.test.ts
- npm run typecheck
- npm test
- npm run build

## Notes
- PR #25 was reviewed, fixed for strict Sparkle appcast history handling, and merged before this branch was rebased onto main.
- The release version guard intentionally makes deploy/check fail for the already-published 1.8.2 until the next release bumps package.json/package-lock/CHANGELOG.