### PR TITLE
Prevent stale launch data from freezing the menu popover

### DIFF
--- a/TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift
+++ b/TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift
@@ -36,6 +36,7 @@ import AppKit
     private var dormantTimer: Timer?
     private var pulseTimer: Timer?
     private var backgroundFullTimer: Timer?
+    private var pendingFreshPopoverRefresh = false
 
     private var activeAgents: [String] = []
     private var isPulseSampling = false
@@ -178,7 +179,10 @@ import AppKit
     /// regardless of whether it came from a manual click, the background timer,
     /// or a previous popover open.
     func refreshOnPopoverOpenIfNeeded() async -> Bool {
-        guard !state.isRefreshing else { return false }
+        if state.isRefreshing {
+            pendingFreshPopoverRefresh = true
+            return false
+        }
         let currentTime = now()
         if let lastUpdatedAt = state.lastUpdatedAt,
            currentTime.timeIntervalSince(lastUpdatedAt) < popoverRefreshInterval {
@@ -241,6 +245,12 @@ import AppKit
         defer {
             state.isLoading = false
             state.isRefreshing = false
+            if forceRefresh {
+                pendingFreshPopoverRefresh = false
+            } else if pendingFreshPopoverRefresh && mode == .active {
+                pendingFreshPopoverRefresh = false
+                Task { await self.refreshOnPopoverOpenIfNeeded() }
+            }
         }
         do {
             let agentsResp = try await api.getAgents()
@@ -318,7 +328,14 @@ import AppKit
             } else {
                 Task { await self.refreshQuota(force: false) }
             }
-            self.state.lastUpdatedAt = now()
+            // Only a cache-bypassing detail refresh proves the popover is fresh.
+            // The launch warm-up intentionally uses refresh=false and may be
+            // served from the daemon's stale disk cache; recording it here would
+            // suppress the first popover-open refresh and leave the menu showing
+            // zeroes until the next background/manual refresh.
+            if forceRefresh {
+                self.state.lastUpdatedAt = now()
+            }
         } catch {
             NSLog("[TokenDash] full update error: \(error.localizedDescription)")
             self.state.errorMessage = error.localizedDescription

--- a/TokenDashSwift/Tests/TokenDashTests/BadgeUpdaterModeTests.swift
+++ b/TokenDashSwift/Tests/TokenDashTests/BadgeUpdaterModeTests.swift
@@ -105,7 +105,7 @@ final class BadgeUpdaterModeTests: XCTestCase {
         await mock.releaseFirstDaily()
         await launchTask.value
         try await waitUntil {
-            await mock.dailyCallCount >= 2
+            await mock.dailyCallCount >= 2 && state.lastUpdatedAt != nil
         }
 
         let lastDailyRefresh = await mock.lastDailyRefresh

--- a/TokenDashSwift/Tests/TokenDashTests/BadgeUpdaterModeTests.swift
+++ b/TokenDashSwift/Tests/TokenDashTests/BadgeUpdaterModeTests.swift
@@ -56,6 +56,63 @@ final class BadgeUpdaterModeTests: XCTestCase {
         XCTAssertFalse(state.isRefreshing, "手动刷新完成后必须退出 loading 状态")
     }
 
+    func testCacheServedLaunchPrimeDoesNotThrottleFirstPopoverRefresh() async throws {
+        let state = AppState()
+        let mock = MockAPIClient()
+        var now = Date(timeIntervalSinceReferenceDate: 1_000)
+        let updater = BadgeUpdater(
+            state: state,
+            client: mock,
+            now: { now },
+            popoverRefreshInterval: 30 * 60
+        )
+
+        await updater.performFullUpdate(forceRefresh: false, forceQuota: false)
+        let launchCounts = await mock.snapshot()
+        let launchDailyRefresh = await mock.lastDailyRefresh
+        XCTAssertEqual(launchDailyRefresh, false, "launch warm-up must stay cache-served")
+        XCTAssertNil(state.lastUpdatedAt, "cache-served launch warm-up must not start the popover fresh-data throttle")
+
+        now.addTimeInterval(60)
+        let refreshedOnOpen = await updater.refreshOnPopoverOpenIfNeeded()
+
+        XCTAssertTrue(refreshedOnOpen, "the first popover open after launch must still bypass stale daemon caches")
+        let openedCounts = await mock.snapshot()
+        XCTAssertGreaterThan(openedCounts.daily, launchCounts.daily)
+        XCTAssertGreaterThan(openedCounts.blocks, launchCounts.blocks)
+        XCTAssertGreaterThan(openedCounts.projects, launchCounts.projects)
+        let openDailyRefresh = await mock.lastDailyRefresh
+        XCTAssertEqual(openDailyRefresh, true, "popover open must force a fresh detail refresh after cache-served launch warm-up")
+        XCTAssertNotNil(state.lastUpdatedAt, "fresh popover refresh should record the throttle timestamp")
+    }
+
+    func testPopoverOpenDuringLaunchWarmupQueuesFreshRefresh() async throws {
+        let state = AppState()
+        let mock = BlockingAPIClient()
+        let updater = BadgeUpdater(
+            state: state,
+            client: mock,
+            popoverRefreshInterval: 30 * 60
+        )
+
+        let launchTask = Task { await updater.performFullUpdate(forceRefresh: false, forceQuota: false) }
+        await mock.waitUntilFirstDailyIsBlocked()
+        updater.setMode(.active)
+
+        let refreshedImmediately = await updater.refreshOnPopoverOpenIfNeeded()
+        XCTAssertFalse(refreshedImmediately, "an in-flight launch warm-up cannot be interrupted synchronously")
+
+        await mock.releaseFirstDaily()
+        await launchTask.value
+        try await waitUntil {
+            await mock.dailyCallCount >= 2
+        }
+
+        let lastDailyRefresh = await mock.lastDailyRefresh
+        XCTAssertEqual(lastDailyRefresh, true, "active popover open during cache-served launch warm-up must queue a fresh refresh")
+        XCTAssertNotNil(state.lastUpdatedAt, "queued fresh refresh should record the throttle timestamp")
+    }
+
     func testPopoverRefreshIsThrottledForThirtyMinutes() async throws {
         let state = AppState()
         let mock = MockAPIClient()
@@ -176,5 +233,68 @@ actor MockAPIClient: APIClientProtocol {
         quota += 1
         lastQuotaRefresh = refresh
         return QuotaResponse(providers: [])
+    }
+}
+
+private func waitUntil(
+    timeoutNanoseconds: UInt64 = 1_000_000_000,
+    condition: @escaping () async -> Bool
+) async throws {
+    let start = DispatchTime.now().uptimeNanoseconds
+    while DispatchTime.now().uptimeNanoseconds - start < timeoutNanoseconds {
+        if await condition() { return }
+        try await Task.sleep(nanoseconds: 10_000_000)
+    }
+    XCTFail("Timed out waiting for async condition")
+}
+
+actor BlockingAPIClient: APIClientProtocol {
+    private(set) var dailyCallCount = 0
+    private(set) var lastDailyRefresh: Bool? = nil
+    private var shouldBlockFirstDaily = true
+    private var firstDailyContinuation: CheckedContinuation<Void, Never>?
+    private var blockedWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func waitUntilFirstDailyIsBlocked() async {
+        if firstDailyContinuation != nil { return }
+        await withCheckedContinuation { continuation in
+            blockedWaiters.append(continuation)
+        }
+    }
+
+    func releaseFirstDaily() {
+        firstDailyContinuation?.resume()
+        firstDailyContinuation = nil
+    }
+
+    func getAgents() async throws -> AgentsResponse {
+        AgentsResponse(available: ["claude"], default: "claude")
+    }
+
+    func getDaily(agent: String, refresh: Bool) async throws -> DailyResponse {
+        dailyCallCount += 1
+        lastDailyRefresh = refresh
+        if shouldBlockFirstDaily {
+            shouldBlockFirstDaily = false
+            await withCheckedContinuation { continuation in
+                firstDailyContinuation = continuation
+                let waiters = blockedWaiters
+                blockedWaiters.removeAll()
+                waiters.forEach { $0.resume() }
+            }
+        }
+        return DailyResponse(daily: [])
+    }
+
+    func getBlocks(agent: String, refresh: Bool) async throws -> BlocksResponse {
+        BlocksResponse(blocks: [])
+    }
+
+    func getProjects(agent: String, refresh: Bool) async throws -> ProjectsResponse {
+        ProjectsResponse(projects: [:])
+    }
+
+    func getQuota(refresh: Bool) async throws -> QuotaResponse {
+        QuotaResponse(providers: [])
     }
 }


### PR DESCRIPTION
## Summary

- keep cache-served launch warm-up from advancing the native menu popover freshness throttle
- queue a cache-bypassing detail refresh when the Swift menu is opened while launch warm-up is still in flight
- add Swift regression coverage for both stale launch data and first-open-during-warm-up paths

## Root cause

The native macOS menu is SwiftUI (`PopoverView` in `NSHostingController`), not the legacy bundled `popover.html`. The transient "all zero" state is caused by the launch warm-up using `performFullUpdate(forceRefresh: false)` against the daemon's stale-while-revalidate disk cache, then recording `lastUpdatedAt`. After v1.8.2, `refreshOnPopoverOpenIfNeeded()` uses `lastUpdatedAt` as the 30-minute popover freshness throttle, so the first menu open after an upgrade/warm-up can skip its intended `refresh=true` cache-bypassing refresh and keep the stale/zero launch state until a later background or manual refresh.

This PR treats only `forceRefresh=true` detail refreshes as proof of fresh popover data, and it records a pending fresh refresh if the user opens the menu while the launch warm-up is still running.

Note: `/popover.html` still has a separate localhost-vs-127.0.0.1 CORS issue, but it is not the native Swift menu execution path; that is left out of this focused fix.

## Verification

- `cd TokenDashSwift && swift test`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `cd TokenDashSwift && swift build -c release`
