### PR TITLE
Keep Codex usage totals stable after archiving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### v1.8.7
+- **Show billion-scale token totals cleanly** — render token values at 1,000M and above with a `B` suffix in the dashboard, menu-bar popover, and native status views instead of showing `1000M`.
+
 ### v1.8.6
 - **Keep Codex usage stable after archiving** — include `~/.codex/archived_sessions` alongside live `~/.codex/sessions` when building Codex usage totals, so today/month totals do not drop after Codex moves completed transcripts into the archive.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### v1.8.6
+- **Keep Codex usage stable after archiving** — include `~/.codex/archived_sessions` alongside live `~/.codex/sessions` when building Codex usage totals, so today/month totals do not drop after Codex moves completed transcripts into the archive.
+
 ### v1.8.5
 - **Correct Codex GPT-5.6 usage accounting** — normalize GPT-5.6 aliases and date-suffixed model names, apply long-context pricing per request, and remove replayed subagent history that could inflate usage totals.
 - **Clearer macOS installation guidance** — ship a compact, centered Finder drag-to-Applications layout with a visible installation instruction and aligned drag arrow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Changelog
 
 ### v1.8.7
-- **Show billion-scale token totals cleanly** — render token values at 1,000M and above with a `B` suffix in the dashboard, menu-bar popover, and native status views instead of showing `1000M`.
-
-### v1.8.6
 - **Keep Codex usage stable after archiving** — include `~/.codex/archived_sessions` alongside live `~/.codex/sessions` when building Codex usage totals, so today/month totals do not drop after Codex moves completed transcripts into the archive.
+- **Show billion-scale token totals cleanly** — render token values at 1,000M and above with a `B` suffix in the dashboard, menu-bar popover, and native status views instead of showing `1000M`.
 
 ### v1.8.5
 - **Correct Codex GPT-5.6 usage accounting** — normalize GPT-5.6 aliases and date-suffixed model names, apply long-context pricing per request, and remove replayed subagent history that could inflate usage totals.

--- a/TokenDashSwift/Sources/TokenDash/Helpers.swift
+++ b/TokenDashSwift/Sources/TokenDash/Helpers.swift
@@ -33,6 +33,7 @@ extension Color {
 // MARK: - Number formatting
 
 func formatTokens(_ tokens: Int) -> String {
+    if tokens >= 1_000_000_000 { return trimTrailingZero(String(format: "%.1f", Double(tokens) / 1_000_000_000)) + "B" }
     if tokens >= 1_000_000 { return String(format: "%.1fM", Double(tokens) / 1_000_000) }
     if tokens >= 1_000 { return String(format: "%.1fK", Double(tokens) / 1_000) }
     if tokens > 0 { return String(tokens) }

--- a/TokenDashSwift/Sources/TokenDash/Helpers.swift
+++ b/TokenDashSwift/Sources/TokenDash/Helpers.swift
@@ -33,7 +33,7 @@ extension Color {
 // MARK: - Number formatting
 
 func formatTokens(_ tokens: Int) -> String {
-    if tokens >= 1_000_000_000 { return trimTrailingZero(String(format: "%.1f", Double(tokens) / 1_000_000_000)) + "B" }
+    if tokens >= 999_950_000 { return trimTrailingZero(String(format: "%.1f", Double(tokens) / 1_000_000_000)) + "B" }
     if tokens >= 1_000_000 { return String(format: "%.1fM", Double(tokens) / 1_000_000) }
     if tokens >= 1_000 { return String(format: "%.1fK", Double(tokens) / 1_000) }
     if tokens > 0 { return String(tokens) }

--- a/TokenDashSwift/Tests/TokenDashTests/HelpersFormattingTests.swift
+++ b/TokenDashSwift/Tests/TokenDashTests/HelpersFormattingTests.swift
@@ -6,5 +6,6 @@ final class HelpersFormattingTests: XCTestCase {
         XCTAssertEqual(formatTokens(1_000_000_000), "1B")
         XCTAssertEqual(formatTokens(1_500_000_000), "1.5B")
         XCTAssertEqual(formatTokens(2_000_000_000), "2B")
+        XCTAssertEqual(formatTokens(999_950_000), "1B")
     }
 }

--- a/TokenDashSwift/Tests/TokenDashTests/HelpersFormattingTests.swift
+++ b/TokenDashSwift/Tests/TokenDashTests/HelpersFormattingTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import TokenDash
+
+final class HelpersFormattingTests: XCTestCase {
+    func testFormatTokensUsesBillionsAtOneThousandMillion() {
+        XCTAssertEqual(formatTokens(1_000_000_000), "1B")
+        XCTAssertEqual(formatTokens(1_500_000_000), "1.5B")
+        XCTAssertEqual(formatTokens(2_000_000_000), "2B")
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zhangferry-dev/tokendash",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zhangferry-dev/tokendash",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "dependencies": {
         "express": "^5.1.0",
         "open": "^10.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zhangferry-dev/tokendash",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zhangferry-dev/tokendash",
-      "version": "1.8.5",
+      "version": "1.8.6",
       "dependencies": {
         "express": "^5.1.0",
         "open": "^10.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhangferry-dev/tokendash",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "type": "module",
   "description": "Token Usage Analytics Dashboard",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhangferry-dev/tokendash",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "type": "module",
   "description": "Token Usage Analytics Dashboard",
   "publishConfig": {

--- a/public/popover.html
+++ b/public/popover.html
@@ -937,6 +937,7 @@
 
     function formatNumber(n) {
       if (!Number.isFinite(n) || n <= 0) return '0';
+      if (n >= 1e9) return trimTrailingZero((n / 1e9).toFixed(n >= 10e9 ? 1 : 2)) + 'B';
       if (n >= 1e6) return trimTrailingZero((n / 1e6).toFixed(n >= 10e6 ? 1 : 2)) + 'M';
       if (n >= 1e3) return trimTrailingZero((n / 1e3).toFixed(n >= 100e3 ? 0 : 1)) + 'K';
       return String(Math.round(n));

--- a/public/popover.html
+++ b/public/popover.html
@@ -937,7 +937,7 @@
 
     function formatNumber(n) {
       if (!Number.isFinite(n) || n <= 0) return '0';
-      if (n >= 1e9) return trimTrailingZero((n / 1e9).toFixed(n >= 10e9 ? 1 : 2)) + 'B';
+      if (n >= 999950000) return trimTrailingZero((n / 1e9).toFixed(n >= 10e9 ? 1 : 2)) + 'B';
       if (n >= 1e6) return trimTrailingZero((n / 1e6).toFixed(n >= 10e6 ? 1 : 2)) + 'M';
       if (n >= 1e3) return trimTrailingZero((n / 1e3).toFixed(n >= 100e3 ? 0 : 1)) + 'K';
       return String(Math.round(n));

--- a/src/__tests__/client/formatters.test.ts
+++ b/src/__tests__/client/formatters.test.ts
@@ -6,6 +6,7 @@ describe('formatTokens', () => {
     expect(formatTokens(1_000_000_000)).toBe('1B');
     expect(formatTokens(1_500_000_000)).toBe('1.5B');
     expect(formatTokens(2_000_000_000)).toBe('2B');
+    expect(formatTokens(999_950_000)).toBe('1B');
   });
 
   it('formats millions with M suffix', () => {

--- a/src/__tests__/client/formatters.test.ts
+++ b/src/__tests__/client/formatters.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { formatTokens, formatUSD, formatPercent, formatProjectName } from '../../client/utils/formatters.js';
 
 describe('formatTokens', () => {
+  it('formats billions with B suffix instead of 1000M', () => {
+    expect(formatTokens(1_000_000_000)).toBe('1B');
+    expect(formatTokens(1_500_000_000)).toBe('1.5B');
+    expect(formatTokens(2_000_000_000)).toBe('2B');
+  });
+
   it('formats millions with M suffix', () => {
     expect(formatTokens(1_500_000)).toBe('1.5M');
     expect(formatTokens(2_000_000)).toBe('2.0M');

--- a/src/__tests__/server/codexParser.test.ts
+++ b/src/__tests__/server/codexParser.test.ts
@@ -1,14 +1,20 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, it, expect, afterEach } from 'vitest';
-import { buildCodexResponsesFromSessions, deduplicateParsedSessions, parseCodexSession, type ParsedSession } from '../../server/codexParser.js';
+import { buildCodexResponsesFromSessions, deduplicateParsedSessions, parseCodexSession, scanCodexSessions, type ParsedSession } from '../../server/codexParser.js';
 import { calculateCost } from '../../server/codexPricing.js';
 import type { DailyEntry, Totals } from '../../shared/types.js';
 
 const tempDirs: string[] = [];
+const originalCodexHome = process.env.CODEX_HOME;
 
 afterEach(() => {
+  if (originalCodexHome === undefined) {
+    delete process.env.CODEX_HOME;
+  } else {
+    process.env.CODEX_HOME = originalCodexHome;
+  }
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (dir) rmSync(dir, { recursive: true, force: true });
@@ -96,6 +102,27 @@ function sumDaily(entries: DailyEntry[]): Totals {
     totalCost: acc.totalCost + entry.totalCost,
   }), { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 0, totalCost: 0 });
 }
+
+describe('scanCodexSessions', () => {
+  it('keeps archived Codex sessions in the usage source set', () => {
+    const codexHome = mkdtempSync(join(tmpdir(), 'tokendash-codex-home-'));
+    tempDirs.push(codexHome);
+    process.env.CODEX_HOME = codexHome;
+
+    const liveDir = join(codexHome, 'sessions', '2026', '07', '22');
+    const archivedDir = join(codexHome, 'archived_sessions');
+    mkdirSync(liveDir, { recursive: true });
+    mkdirSync(archivedDir, { recursive: true });
+
+    const liveSession = join(liveDir, 'rollout-live.jsonl');
+    const archivedSession = join(archivedDir, 'rollout-archived.jsonl');
+    writeFileSync(liveSession, '');
+    writeFileSync(archivedSession, '');
+    writeFileSync(join(archivedDir, 'ignored.txt'), 'not a session');
+
+    expect(scanCodexSessions()).toEqual([archivedSession, liveSession]);
+  });
+});
 
 describe('parseCodexSession', () => {
   it('deduplicates repeated token_count snapshots within a Codex session', () => {

--- a/src/client/utils/formatters.ts
+++ b/src/client/utils/formatters.ts
@@ -1,4 +1,7 @@
 export function formatTokens(n: number): string {
+  if (n >= 1_000_000_000) {
+    return (n / 1_000_000_000).toFixed(1).replace(/\.0$/, '') + 'B';
+  }
   if (n >= 1_000_000) {
     return (n / 1_000_000).toFixed(1) + 'M';
   }

--- a/src/client/utils/formatters.ts
+++ b/src/client/utils/formatters.ts
@@ -1,5 +1,5 @@
 export function formatTokens(n: number): string {
-  if (n >= 1_000_000_000) {
+  if (n >= 999_950_000) {
     return (n / 1_000_000_000).toFixed(1).replace(/\.0$/, '') + 'B';
   }
   if (n >= 1_000_000) {

--- a/src/server/codexParser.ts
+++ b/src/server/codexParser.ts
@@ -79,7 +79,7 @@ interface AggregateBucket {
   models: Map<string, TokenAccumulator>;
 }
 
-const CODEX_INDEX_VERSION = 'codex-session-v3';
+const CODEX_INDEX_VERSION = 'codex-session-v4';
 const DEFAULT_TZ = 'Asia/Shanghai';
 
 interface SerializedAggregateBucket {
@@ -167,8 +167,18 @@ function displayInputTokens(inputTokens: number, cachedInputTokens: number): num
 // Helpers
 // ---------------------------------------------------------------------------
 
-function getSessionsDir(): string {
-  return join(homedir(), '.codex', 'sessions');
+/** Resolve the Codex data root from CODEX_HOME, falling back to ~/.codex. */
+function getCodexHome(): string {
+  return process.env.CODEX_HOME || join(homedir(), '.codex');
+}
+
+/** Return every Codex transcript directory whose JSONL usage should be counted. */
+function getSessionDirs(): string[] {
+  const codexHome = getCodexHome();
+  return [
+    join(codexHome, 'sessions'),
+    join(codexHome, 'archived_sessions'),
+  ];
 }
 
 /**
@@ -208,19 +218,22 @@ function detectReplaySecond(content: string): string | null {
 }
 
 export function isSessionsDirAccessible(): boolean {
-  try {
-    accessSync(getSessionsDir(), constants.R_OK);
-    return true;
-  } catch {
-    return false;
-  }
+  return getSessionDirs().some(dir => {
+    try {
+      accessSync(dir, constants.R_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  });
 }
 
 /**
- * Recursively find all .jsonl files under ~/.codex/sessions/
+ * Recursively find all .jsonl files under the live and archived Codex session
+ * directories. Codex moves completed transcripts to archived_sessions, but
+ * usage history must remain cumulative after that lifecycle transition.
  */
 export function scanCodexSessions(): string[] {
-  const sessionsDir = getSessionsDir();
   const results: string[] = [];
 
   function walk(dir: string): void {
@@ -246,7 +259,9 @@ export function scanCodexSessions(): string[] {
     }
   }
 
-  walk(sessionsDir);
+  for (const dir of getSessionDirs()) {
+    walk(dir);
+  }
   return results.sort();
 }
 


### PR DESCRIPTION
## Summary
- Include both live `sessions` and `archived_sessions` under `CODEX_HOME` when scanning Codex JSONL transcripts.
- Treat the expanded source set as a Codex parser index upgrade so local usage indexes rebuild safely.
- Render billion-scale token totals as `B` in the React dashboard, menu-bar popover HTML, and native Swift views instead of `1000M`.
- Add regression coverage for archived Codex session scanning and billion-token formatting.
- Bump package version to v1.8.7 and document both fixes in the changelog.

## Verification
- `npm test -- src/__tests__/server/codexParser.test.ts`
- `npm test -- src/__tests__/client/formatters.test.ts`
- `cd TokenDashSwift && swift test`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `npm run test:e2e`
- Source parser proof with temporary `TOKENDASH_USAGE_INDEX_DIR`: 2026-07-22 Codex total = 303.541M including archives
- Public popover formatter smoke returned `1B`, `1.5B`, `12.3B`
