### PR TITLE
Keep live token totals from freezing behind caches

### DIFF
--- a/TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift
+++ b/TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift
@@ -6,10 +6,10 @@ import AppKit
 ///
 /// Refresh is driven by a three-state machine (`RefreshMode`) instead of a fixed
 /// high-frequency timer:
-/// - `.dormant`  — popover closed: cheap badge updates plus a configurable
-///                 background refresh of the popover's detail data.
-/// - `.active`   — popover open: a full refresh at most once every 30 minutes;
-///                 subsequent refreshes are manual until the interval elapses.
+/// - `.dormant`  — popover closed: fresh badge totals every 30s plus a
+///                 configurable background refresh of detail data.
+/// - `.active`   — popover open: immediate fresh detail data, then a 60s fresh
+///                 detail refresh while the user is looking at the popover.
 /// - `.suspended`— system sleep / low power: all data timers stopped.
 @MainActor class BadgeUpdater {
     private let state: AppState
@@ -18,10 +18,12 @@ import AppKit
     enum RefreshMode { case dormant, active, suspended }
     private(set) var mode: RefreshMode = .dormant
 
-    // Cadences (seconds). The badge is cache-served and stays cheap; detail data
-    // refreshes in the background at the user-selected cadence.
+    // Cadences (seconds). The badge refresh parses only changed usage files via
+    // the daemon's usage index, so it stays cheap while reflecting live agent use.
+    // Detail data also refreshes while the popover is visible.
     private let dormantInterval: TimeInterval = 30
     private let activePulseInterval: TimeInterval = 10.0
+    private let activeDetailInterval: TimeInterval
     private let backgroundFullIntervalOverride: TimeInterval?
     private var backgroundFullInterval: TimeInterval {
         backgroundFullIntervalOverride ?? SettingsStore.shared.refreshInterval.rawValue
@@ -35,6 +37,7 @@ import AppKit
 
     private var dormantTimer: Timer?
     private var pulseTimer: Timer?
+    private var activeDetailTimer: Timer?
     private var backgroundFullTimer: Timer?
     private var pendingFreshPopoverRefresh = false
 
@@ -53,13 +56,15 @@ import AppKit
         client: (any APIClientProtocol)? = nil,
         now: @escaping () -> Date = Date.init,
         backgroundFullInterval: TimeInterval? = nil,
-        popoverRefreshInterval: TimeInterval = 30 * 60
+        popoverRefreshInterval: TimeInterval = 30 * 60,
+        activeDetailInterval: TimeInterval = 60
     ) {
         self.state = state
         self.apiClient = client
         self.now = now
         self.backgroundFullIntervalOverride = backgroundFullInterval
         self.popoverRefreshInterval = popoverRefreshInterval
+        self.activeDetailInterval = activeDetailInterval
     }
 
     func start(port: Int) {
@@ -105,6 +110,7 @@ import AppKit
             Task { await self.performBadgeUpdate() }   // immediate refresh on entry
         case .active:
             Task { await self.refreshOnPopoverOpenIfNeeded() }
+            scheduleActiveDetail()
             if pulseEnabled {
                 samplePulse()  // prime a pulse baseline immediately, don't wait 10s
                 schedulePulse()
@@ -131,6 +137,14 @@ import AppKit
         pulseTimer = t
     }
 
+    private func scheduleActiveDetail() {
+        let t = Timer(timeInterval: activeDetailInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in await self?.performActiveDetailRefresh() }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        activeDetailTimer = t
+    }
+
     private func scheduleBackgroundFull() {
         guard backgroundFullTimer == nil else { return }
         let t = Timer(timeInterval: backgroundFullInterval, repeats: true) { [weak self] _ in
@@ -148,6 +162,7 @@ import AppKit
     private func stopDataTimers() {
         dormantTimer?.invalidate(); dormantTimer = nil
         pulseTimer?.invalidate(); pulseTimer = nil
+        activeDetailTimer?.invalidate(); activeDetailTimer = nil
     }
 
     func stop() {
@@ -174,6 +189,14 @@ import AppKit
         await performFullUpdate(forceRefresh: true, forceQuota: true)
     }
 
+    /// Full detail refresh while the popover is visible. It bypasses usage caches
+    /// so live coding-agent activity is reflected without waiting for the
+    /// low-power background cadence, but quota remains cached to avoid repeated
+    /// upstream calls.
+    func performActiveDetailRefresh() async {
+        await performFullUpdate(forceRefresh: true, forceQuota: false)
+    }
+
     /// Returns true when opening the popover triggered its allowed automatic
     /// refresh. The throttle is based on the most recent full detail refresh,
     /// regardless of whether it came from a manual click, the background timer,
@@ -194,9 +217,10 @@ import AppKit
 
     // MARK: - dormant: cheap badge update (cache-served)
 
-    /// Updates only today's total tokens + cost for the menu bar badge. Served
-    /// from the daemon's 5min cache (refresh:false) so it never triggers JSONL
-    /// re-parsing. Does not touch detail state (hourly/projects/trend/quota).
+    /// Updates only today's total tokens + cost for the menu bar badge. This
+    /// bypasses the daemon response cache because the badge is the primary live
+    /// signal that coding-agent usage is still moving. The daemon usage index
+    /// reparses only changed files, and this still avoids blocks/projects/quota.
     func performBadgeUpdate() async {
         guard let api = apiClient else { return }
         do {
@@ -208,7 +232,7 @@ import AppKit
             var totalTokens = 0
             var totalCost = 0.0
             for agent in agents {
-                if let d = try? await api.getDaily(agent: agent, refresh: false) {
+                if let d = try? await api.getDaily(agent: agent, refresh: true) {
                     if let entry = d.daily.first(where: { $0.date == today }) {
                         totalTokens += entry.totalTokens
                         totalCost += entry.totalCost

--- a/TokenDashSwift/Tests/TokenDashTests/BadgeUpdaterModeTests.swift
+++ b/TokenDashSwift/Tests/TokenDashTests/BadgeUpdaterModeTests.swift
@@ -4,9 +4,9 @@ import XCTest
 @MainActor
 final class BadgeUpdaterModeTests: XCTestCase {
 
-    // MARK: - dormant: badge 更新只拉 daily，不拉 blocks/projects/quota
+    // MARK: - dormant: badge 更新只强刷 daily，不拉 blocks/projects/quota
 
-    func testDormantPerformBadgeUpdateSkipsBlocksProjectsQuota() async throws {
+    func testDormantPerformBadgeUpdateForceRefreshesDailyButSkipsBlocksProjectsQuota() async throws {
         let state = AppState()
         let mock = MockAPIClient()
         let updater = BadgeUpdater(state: state, client: mock)
@@ -15,6 +15,8 @@ final class BadgeUpdaterModeTests: XCTestCase {
 
         let counts = await mock.snapshot()
         XCTAssertGreaterThan(counts.daily, 0, "dormant badge 更新必须拉 daily")
+        let lastDailyRefresh = await mock.lastDailyRefresh
+        XCTAssertEqual(lastDailyRefresh, true, "菜单栏 token 数必须绕过 daemon 响应缓存，否则 coding agent 使用中会停住")
         XCTAssertEqual(counts.blocks, 0, "dormant 不得拉 blocks")
         XCTAssertEqual(counts.projects, 0, "dormant 不得拉 projects")
         XCTAssertEqual(counts.quota, 0, "dormant 不得拉 quota")
@@ -39,6 +41,28 @@ final class BadgeUpdaterModeTests: XCTestCase {
         XCTAssertGreaterThan(counts.quota, 0, "active 详情刷新最终要拉 quota（异步）")
         let lastQuotaRefresh = await mock.lastQuotaRefresh
         XCTAssertEqual(lastQuotaRefresh, false, "非手动刷新时 quota 必须走缓存")
+    }
+
+
+    func testActiveModeSchedulesFreshDetailRefreshWhilePopoverIsOpen() async throws {
+        let state = AppState()
+        let mock = MockAPIClient()
+        let updater = BadgeUpdater(
+            state: state,
+            client: mock,
+            activeDetailInterval: 0.05
+        )
+
+        updater.setMode(.active)
+        try await waitUntil {
+            await mock.dailyCallCount >= 2
+        }
+        updater.stop()
+
+        let counts = await mock.snapshot()
+        XCTAssertGreaterThanOrEqual(counts.daily, 2, "打开 popover 后必须持续刷新详情，而不是等 30 分钟/1 小时")
+        let lastDailyRefresh = await mock.lastDailyRefresh
+        XCTAssertEqual(lastDailyRefresh, true, "active 详情刷新必须绕过 usage 响应缓存")
     }
 
     // MARK: - 手动刷新：quota 强刷
@@ -203,6 +227,7 @@ actor MockAPIClient: APIClientProtocol {
     private(set) var quota = 0
     private(set) var lastQuotaRefresh: Bool? = nil
     private(set) var lastDailyRefresh: Bool? = nil
+    var dailyCallCount: Int { daily }
 
     struct Snapshot {
         let agents: Int; let daily: Int; let blocks: Int

--- a/src/__tests__/server/nativeAppPackaging.test.ts
+++ b/src/__tests__/server/nativeAppPackaging.test.ts
@@ -237,14 +237,18 @@ esac
     const badgeUpdater = readFileSync('TokenDashSwift/Sources/TokenDash/BadgeUpdater.swift', 'utf8');
     expect(apiClient).toContain('"&refresh=1"');
     expect(apiClient).toContain('"/quota\\(refresh ? "?refresh=1" : "")"');
-    // v1.8.0: detail endpoints take a `forceRefresh` flag — true on popover open
-    // (forces past the cache), false on the 60s background timer (cache-served).
+    // The badge is the primary live signal, so its 30s update must not reuse
+    // the daemon's 5-minute daily response cache.
+    expect(badgeUpdater).toContain('api.getDaily(agent: agent, refresh: true)');
+    // Detail endpoints take a `forceRefresh` flag, with popover-open and active
+    // visible refreshes forcing past the usage cache while quota stays cached.
     expect(badgeUpdater).toContain('api.getDaily(agent: agent, refresh: forceRefresh)');
     expect(badgeUpdater).toContain('api.getBlocks(agent: agent, refresh: forceRefresh)');
     expect(badgeUpdater).toContain('api.getProjects(agent: agent, refresh: forceRefresh)');
     expect(badgeUpdater).toContain('api.getQuota(refresh: force)');
-    // popover open must still force-refresh (the v1.7.5 guarantee, now via flag)
     expect(badgeUpdater).toContain('performFullUpdate(forceRefresh: true, forceQuota: false)');
+    expect(badgeUpdater).toContain('performActiveDetailRefresh');
+    expect(badgeUpdater).toContain('activeDetailInterval: TimeInterval = 60');
     expect(badgeUpdater).toContain('retainUsableQuotas');
     expect(badgeUpdater).toContain('snapshot.freshness != "stale"');
   });


### PR DESCRIPTION
## Summary
- force the native menu bar badge daily fetch past the daemon response cache so the token total keeps moving during live coding-agent use
- restore a fresh 60s detail refresh while the popover is visible, keeping quota cached to avoid repeated upstream calls
- add Swift regression coverage plus static packaging guardrails for cache-bypassing native refreshes

## Root cause
`/api/daily` caches non-refresh responses for 5 minutes and serves stale data while revalidating. v1.8.7's 30s badge update called daily with `refresh=false`, so the visible menu-bar token total could stay flat even while Codex session JSONL files were actively growing. The popover detail view also stopped refreshing after the open-time refresh until the 30min/hourly cadence.

## Verification
- `npm test`
- `npm run typecheck`
- `npm run build`
- `cd TokenDashSwift && swift test`
- `cd TokenDashSwift && swift build -c release`

## Manual evidence
On the installed v1.8.7 app, `GET /api/daily?agent=codex` returned an older total while `GET /api/daily?agent=codex&refresh=true` immediately increased from live Codex usage, confirming the parser/index was updating but the visible path was cache-bound.