### PR TITLE
 ``` feat: add Pi Agent usage analytics support

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -164,6 +164,20 @@ test.describe('Agent: Pi', () => {
   });
 });
 
+test.describe('Dashboard refresh', () => {
+  test('manual refresh bypasses cached dashboard endpoints', async ({ page }) => {
+    await setupPage(page);
+    const paths = ['daily', 'projects', 'blocks', 'analytics'];
+    const refreshRequests = paths.map(path => page.waitForRequest(request => {
+      const url = new URL(request.url());
+      return url.pathname === `/api/${path}` && url.searchParams.get('refresh') === '1';
+    }));
+
+    await page.locator('button[title^="刷新数据"]').click();
+    await Promise.all(refreshRequests);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Time Range tests
 // ---------------------------------------------------------------------------

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -136,6 +136,34 @@ test.describe('Agent: Codex', () => {
   });
 });
 
+test.describe('Agent: Pi', () => {
+  // 使用两个 agent 使切换器可见（单个 agent 时切换器隐藏，Pi 按钮不渲染）
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page, { agents: ['claude', 'pi'] });
+  });
+
+  test('Pi button renders in agent switcher', async ({ page }) => {
+    await expect(page.locator('button:has-text("Pi")')).toBeVisible();
+  });
+
+  test('hides analytics section for Pi', async ({ page }) => {
+    await page.locator('button:has-text("Pi")').click();
+    await page.waitForTimeout(2000);
+
+    const piBtn = page.locator('button:has-text("Pi")');
+    const classes = await piBtn.getAttribute('class') || '';
+    expect(classes).toContain('bg-white');
+
+    await expect(page.locator('text=Code Change Trend')).not.toBeVisible();
+  });
+
+  test('shows KPI data for Pi', async ({ page }) => {
+    await page.locator('button:has-text("Pi")').click();
+    await page.waitForTimeout(2000);
+    await expect(page.locator('span:text-is("Total tokens")')).toBeVisible();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Time Range tests
 // ---------------------------------------------------------------------------

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,4 +1,11 @@
-import type { DailyEntry, DailyResponse, ProjectsResponse, BlocksResponse, BlockEntry, AnalyticsResponse } from '../src/shared/types.js';
+import type {
+  DailyEntry,
+  DailyResponse,
+  ProjectsResponse,
+  BlocksResponse,
+  BlockEntry,
+  AnalyticsResponse,
+} from "../src/shared/types.js";
 
 // ---------------------------------------------------------------------------
 // Date helpers — all dates are relative to "now" so tests work on any day
@@ -16,7 +23,7 @@ function fmtDate(d: Date): string {
 }
 
 function fmtHour(d: Date): string {
-  return d.toISOString().slice(0, 13).replace('T', ' ') + ':00';
+  return d.toISOString().slice(0, 13).replace("T", " ") + ":00";
 }
 
 function todayStr(): string {
@@ -36,7 +43,11 @@ function seededValue(seed: number): number {
 // Daily entries
 // ---------------------------------------------------------------------------
 
-function makeDailyEntry(date: string, models: string[], seed: number): DailyEntry {
+function makeDailyEntry(
+  date: string,
+  models: string[],
+  seed: number,
+): DailyEntry {
   const total = seededValue(seed);
   const inputRatio = 0.4;
   const outputRatio = 0.1;
@@ -57,7 +68,7 @@ function makeDailyEntry(date: string, models: string[], seed: number): DailyEntr
     totalTokens: totalInput + totalOutput + totalCacheRead,
     totalCost: 0,
     modelsUsed: models,
-    modelBreakdowns: models.map(name => ({
+    modelBreakdowns: models.map((name) => ({
       modelName: name,
       inputTokens: perModel(totalInput),
       outputTokens: perModel(totalOutput),
@@ -72,14 +83,19 @@ function makeDailyEntry(date: string, models: string[], seed: number): DailyEntr
 // Block (hourly) entries
 // ---------------------------------------------------------------------------
 
-function makeBlock(date: Date, hour: number, models: string[], idx: number): BlockEntry {
+function makeBlock(
+  date: Date,
+  hour: number,
+  models: string[],
+  idx: number,
+): BlockEntry {
   const val = seededValue(idx * 100 + hour);
   const input = Math.round(val * 0.4);
   const output = Math.round(val * 0.1);
   const cacheRead = Math.round(val * 0.5);
 
   const d = fmtDate(date);
-  const h = String(hour).padStart(2, '0');
+  const h = String(hour).padStart(2, "0");
 
   return {
     id: `block-${idx}`,
@@ -113,36 +129,37 @@ interface AgentConfig {
 
 const AGENT_CONFIGS: Record<string, AgentConfig> = {
   claude: {
-    models: ['claude-sonnet-4-5', 'claude-opus-4-5'],
+    models: ["claude-sonnet-4-5", "claude-opus-4-5"],
     projects: [
-      { path: '/Users/test/project-alpha', weight: 3 },
-      { path: '/Users/test/project-beta', weight: 2 },
-      { path: '/Users/test/project-gamma', weight: 1 },
+      { path: "/Users/test/project-alpha", weight: 3 },
+      { path: "/Users/test/project-beta", weight: 2 },
+      { path: "/Users/test/project-gamma", weight: 1 },
     ],
     hasAnalytics: true,
   },
   opencode: {
-    models: ['glm-4.7', 'mimo-v2.5-pro'],
+    models: ["glm-4.7", "mimo-v2.5-pro"],
     projects: [
-      { path: '/Users/test/workspace-a/task-1/workdir', weight: 3 },
-      { path: '/Users/test/workspace-b/task-2/workdir', weight: 2 },
-      { path: '/Users/test/my-project', weight: 1 },
+      { path: "/Users/test/workspace-a/task-1/workdir", weight: 3 },
+      { path: "/Users/test/workspace-b/task-2/workdir", weight: 2 },
+      { path: "/Users/test/my-project", weight: 1 },
     ],
     hasAnalytics: false,
   },
   codex: {
-    models: ['o3', 'o4-mini'],
-    projects: [
-      { path: '/Users/test/codex-project', weight: 2 },
-    ],
+    models: ["o3", "o4-mini"],
+    projects: [{ path: "/Users/test/codex-project", weight: 2 }],
     hasAnalytics: false,
   },
   openclaw: {
-    models: ['gpt-4.1', 'gpt-4.1-mini'],
-    projects: [
-      { path: '/Users/test/openclaw-project', weight: 2 },
-    ],
+    models: ["gpt-4.1", "gpt-4.1-mini"],
+    projects: [{ path: "/Users/test/openclaw-project", weight: 2 }],
     hasAnalytics: true,
+  },
+  pi: {
+    models: ["qwen3.8-max-preview", "claude-sonnet-4-5"],
+    projects: [{ path: "D:\\file\\tokendash", weight: 3 }],
+    hasAnalytics: false,
   },
 };
 
@@ -170,7 +187,14 @@ export function generateDailyResponse(agent: string): DailyResponse {
       totalTokens: acc.totalTokens + d.totalTokens,
       totalCost: acc.totalCost + d.totalCost,
     }),
-    { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 0, totalCost: 0 },
+    {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+      totalTokens: 0,
+      totalCost: 0,
+    },
   );
 
   return { daily, totals };
@@ -183,7 +207,10 @@ export function generateProjectsResponse(agent: string): ProjectsResponse {
   for (const proj of config.projects) {
     const entries: DailyEntry[] = [];
     // Distribute days across projects by weight
-    const projDays = Math.round(TOTAL_DAYS * (proj.weight / config.projects.reduce((s, p) => s + p.weight, 0)));
+    const projDays = Math.round(
+      TOTAL_DAYS *
+        (proj.weight / config.projects.reduce((s, p) => s + p.weight, 0)),
+    );
     for (let i = projDays; i >= 0; i--) {
       const date = fmtDate(daysAgo(i));
       entries.push(makeDailyEntry(date, config.models, (i + 1) * 7));
@@ -213,13 +240,21 @@ export function generateBlocksResponse(agent: string): BlocksResponse {
   return { blocks };
 }
 
-export function generateAnalyticsResponse(agent: string): AnalyticsResponse | null {
+export function generateAnalyticsResponse(
+  agent: string,
+): AnalyticsResponse | null {
   const config = AGENT_CONFIGS[agent] || AGENT_CONFIGS.claude;
   if (!config.hasAnalytics) return null;
 
   const codeChangeTrend = [];
   const toolCallTrend: Array<Record<string, string | number>> = [];
-  const toolMap: Record<string, number> = { Read: 0, Edit: 0, Bash: 0, Grep: 0, Write: 0 };
+  const toolMap: Record<string, number> = {
+    Read: 0,
+    Edit: 0,
+    Bash: 0,
+    Grep: 0,
+    Write: 0,
+  };
 
   for (let i = 30; i >= 0; i--) {
     const date = fmtDate(daysAgo(i));
@@ -265,7 +300,9 @@ export function generateAnalyticsResponse(agent: string): AnalyticsResponse | nu
 // Agents detection response
 // ---------------------------------------------------------------------------
 
-export function generateAgentsResponse(agentList: string[] = ['claude', 'opencode', 'codex']) {
+export function generateAgentsResponse(
+  agentList: string[] = ["claude", "opencode", "codex"],
+) {
   return {
     available: agentList,
     default: agentList[0],
@@ -284,10 +321,10 @@ export interface FixtureOverrides {
 }
 
 export async function mockApiRoutes(
-  page: import('@playwright/test').Page,
+  page: import("@playwright/test").Page,
   overrides: FixtureOverrides = {},
 ) {
-  const agentList = overrides.agents || ['claude', 'opencode', 'codex'];
+  const agentList = overrides.agents || ["claude", "opencode", "codex"];
   const cache = new Map<string, unknown>();
 
   function getOrGenerate(key: string, generator: () => unknown): unknown {
@@ -295,44 +332,56 @@ export async function mockApiRoutes(
     return cache.get(key);
   }
 
-  await page.route('**/api/**', async (route) => {
+  await page.route("**/api/**", async (route) => {
     const url = new URL(route.request().url());
-    const path = url.pathname.replace('/api/', '');
-    const agent = url.searchParams.get('agent') || 'claude';
+    const path = url.pathname.replace("/api/", "");
+    const agent = url.searchParams.get("agent") || "claude";
 
     switch (path) {
-      case 'agents':
+      case "agents":
         if (overrides.emptyAgents) {
           await route.fulfill({ json: generateAgentsResponse([]) });
         } else {
-          await route.fulfill({ json: getOrGenerate('agents', () => generateAgentsResponse(agentList)) });
-        }
-        break;
-
-      case 'daily':
-        await route.fulfill({
-          json: getOrGenerate(`daily:${agent}`, () => generateDailyResponse(agent)),
-        });
-        break;
-
-      case 'projects':
-        await route.fulfill({
-          json: getOrGenerate(`projects:${agent}`, () => generateProjectsResponse(agent)),
-        });
-        break;
-
-      case 'blocks':
-        if (overrides.noBlocks) {
-          await route.fulfill({ json: { blocks: [] } });
-        } else {
           await route.fulfill({
-            json: getOrGenerate(`blocks:${agent}`, () => generateBlocksResponse(agent)),
+            json: getOrGenerate("agents", () =>
+              generateAgentsResponse(agentList),
+            ),
           });
         }
         break;
 
-      case 'analytics': {
-        const analytics = getOrGenerate(`analytics:${agent}`, () => generateAnalyticsResponse(agent));
+      case "daily":
+        await route.fulfill({
+          json: getOrGenerate(`daily:${agent}`, () =>
+            generateDailyResponse(agent),
+          ),
+        });
+        break;
+
+      case "projects":
+        await route.fulfill({
+          json: getOrGenerate(`projects:${agent}`, () =>
+            generateProjectsResponse(agent),
+          ),
+        });
+        break;
+
+      case "blocks":
+        if (overrides.noBlocks) {
+          await route.fulfill({ json: { blocks: [] } });
+        } else {
+          await route.fulfill({
+            json: getOrGenerate(`blocks:${agent}`, () =>
+              generateBlocksResponse(agent),
+            ),
+          });
+        }
+        break;
+
+      case "analytics": {
+        const analytics = getOrGenerate(`analytics:${agent}`, () =>
+          generateAnalyticsResponse(agent),
+        );
         if (analytics) {
           await route.fulfill({ json: analytics });
         } else {
@@ -341,7 +390,14 @@ export async function mockApiRoutes(
             json: {
               codeChangeTrend: [],
               toolUsageDistribution: [],
-              productivityKPIs: { avgLinesPerEdit: 0, filesModifiedPerDay: 0, addDeleteRatio: 0, totalEdits: 0, totalFilesModified: 0, activeDaysWithEdits: 0 },
+              productivityKPIs: {
+                avgLinesPerEdit: 0,
+                filesModifiedPerDay: 0,
+                addDeleteRatio: 0,
+                totalEdits: 0,
+                totalFilesModified: 0,
+                activeDaysWithEdits: 0,
+              },
               toolCallTrend: [],
             },
           });

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,11 +1,4 @@
-import type {
-  DailyEntry,
-  DailyResponse,
-  ProjectsResponse,
-  BlocksResponse,
-  BlockEntry,
-  AnalyticsResponse,
-} from "../src/shared/types.js";
+import type { DailyEntry, DailyResponse, ProjectsResponse, BlocksResponse, BlockEntry, AnalyticsResponse } from '../src/shared/types.js';
 
 // ---------------------------------------------------------------------------
 // Date helpers — all dates are relative to "now" so tests work on any day
@@ -23,7 +16,7 @@ function fmtDate(d: Date): string {
 }
 
 function fmtHour(d: Date): string {
-  return d.toISOString().slice(0, 13).replace("T", " ") + ":00";
+  return d.toISOString().slice(0, 13).replace('T', ' ') + ':00';
 }
 
 function todayStr(): string {
@@ -43,11 +36,7 @@ function seededValue(seed: number): number {
 // Daily entries
 // ---------------------------------------------------------------------------
 
-function makeDailyEntry(
-  date: string,
-  models: string[],
-  seed: number,
-): DailyEntry {
+function makeDailyEntry(date: string, models: string[], seed: number): DailyEntry {
   const total = seededValue(seed);
   const inputRatio = 0.4;
   const outputRatio = 0.1;
@@ -68,7 +57,7 @@ function makeDailyEntry(
     totalTokens: totalInput + totalOutput + totalCacheRead,
     totalCost: 0,
     modelsUsed: models,
-    modelBreakdowns: models.map((name) => ({
+    modelBreakdowns: models.map(name => ({
       modelName: name,
       inputTokens: perModel(totalInput),
       outputTokens: perModel(totalOutput),
@@ -83,19 +72,14 @@ function makeDailyEntry(
 // Block (hourly) entries
 // ---------------------------------------------------------------------------
 
-function makeBlock(
-  date: Date,
-  hour: number,
-  models: string[],
-  idx: number,
-): BlockEntry {
+function makeBlock(date: Date, hour: number, models: string[], idx: number): BlockEntry {
   const val = seededValue(idx * 100 + hour);
   const input = Math.round(val * 0.4);
   const output = Math.round(val * 0.1);
   const cacheRead = Math.round(val * 0.5);
 
   const d = fmtDate(date);
-  const h = String(hour).padStart(2, "0");
+  const h = String(hour).padStart(2, '0');
 
   return {
     id: `block-${idx}`,
@@ -129,36 +113,43 @@ interface AgentConfig {
 
 const AGENT_CONFIGS: Record<string, AgentConfig> = {
   claude: {
-    models: ["claude-sonnet-4-5", "claude-opus-4-5"],
+    models: ['claude-sonnet-4-5', 'claude-opus-4-5'],
     projects: [
-      { path: "/Users/test/project-alpha", weight: 3 },
-      { path: "/Users/test/project-beta", weight: 2 },
-      { path: "/Users/test/project-gamma", weight: 1 },
+      { path: '/Users/test/project-alpha', weight: 3 },
+      { path: '/Users/test/project-beta', weight: 2 },
+      { path: '/Users/test/project-gamma', weight: 1 },
     ],
     hasAnalytics: true,
   },
   opencode: {
-    models: ["glm-4.7", "mimo-v2.5-pro"],
+    models: ['glm-4.7', 'mimo-v2.5-pro'],
     projects: [
-      { path: "/Users/test/workspace-a/task-1/workdir", weight: 3 },
-      { path: "/Users/test/workspace-b/task-2/workdir", weight: 2 },
-      { path: "/Users/test/my-project", weight: 1 },
+      { path: '/Users/test/workspace-a/task-1/workdir', weight: 3 },
+      { path: '/Users/test/workspace-b/task-2/workdir', weight: 2 },
+      { path: '/Users/test/my-project', weight: 1 },
     ],
     hasAnalytics: false,
   },
   codex: {
-    models: ["o3", "o4-mini"],
-    projects: [{ path: "/Users/test/codex-project", weight: 2 }],
+    models: ['o3', 'o4-mini'],
+    projects: [
+      { path: '/Users/test/codex-project', weight: 2 },
+    ],
     hasAnalytics: false,
   },
   openclaw: {
-    models: ["gpt-4.1", "gpt-4.1-mini"],
-    projects: [{ path: "/Users/test/openclaw-project", weight: 2 }],
+    models: ['gpt-4.1', 'gpt-4.1-mini'],
+    projects: [
+      { path: '/Users/test/openclaw-project', weight: 2 },
+    ],
     hasAnalytics: true,
   },
   pi: {
-    models: ["qwen3.8-max-preview", "claude-sonnet-4-5"],
-    projects: [{ path: "D:\\file\\tokendash", weight: 3 }],
+    models: ['qwen3.8-max-preview', 'claude-sonnet-4-5'],
+    projects: [
+      { path: 'D:\\file\\tokendash', weight: 3 },
+      { path: 'D:\\file\\Zed', weight: 2 },
+    ],
     hasAnalytics: false,
   },
 };
@@ -187,14 +178,7 @@ export function generateDailyResponse(agent: string): DailyResponse {
       totalTokens: acc.totalTokens + d.totalTokens,
       totalCost: acc.totalCost + d.totalCost,
     }),
-    {
-      inputTokens: 0,
-      outputTokens: 0,
-      cacheCreationTokens: 0,
-      cacheReadTokens: 0,
-      totalTokens: 0,
-      totalCost: 0,
-    },
+    { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 0, totalCost: 0 },
   );
 
   return { daily, totals };
@@ -207,10 +191,7 @@ export function generateProjectsResponse(agent: string): ProjectsResponse {
   for (const proj of config.projects) {
     const entries: DailyEntry[] = [];
     // Distribute days across projects by weight
-    const projDays = Math.round(
-      TOTAL_DAYS *
-        (proj.weight / config.projects.reduce((s, p) => s + p.weight, 0)),
-    );
+    const projDays = Math.round(TOTAL_DAYS * (proj.weight / config.projects.reduce((s, p) => s + p.weight, 0)));
     for (let i = projDays; i >= 0; i--) {
       const date = fmtDate(daysAgo(i));
       entries.push(makeDailyEntry(date, config.models, (i + 1) * 7));
@@ -240,21 +221,13 @@ export function generateBlocksResponse(agent: string): BlocksResponse {
   return { blocks };
 }
 
-export function generateAnalyticsResponse(
-  agent: string,
-): AnalyticsResponse | null {
+export function generateAnalyticsResponse(agent: string): AnalyticsResponse | null {
   const config = AGENT_CONFIGS[agent] || AGENT_CONFIGS.claude;
   if (!config.hasAnalytics) return null;
 
   const codeChangeTrend = [];
   const toolCallTrend: Array<Record<string, string | number>> = [];
-  const toolMap: Record<string, number> = {
-    Read: 0,
-    Edit: 0,
-    Bash: 0,
-    Grep: 0,
-    Write: 0,
-  };
+  const toolMap: Record<string, number> = { Read: 0, Edit: 0, Bash: 0, Grep: 0, Write: 0 };
 
   for (let i = 30; i >= 0; i--) {
     const date = fmtDate(daysAgo(i));
@@ -300,9 +273,7 @@ export function generateAnalyticsResponse(
 // Agents detection response
 // ---------------------------------------------------------------------------
 
-export function generateAgentsResponse(
-  agentList: string[] = ["claude", "opencode", "codex"],
-) {
+export function generateAgentsResponse(agentList: string[] = ['claude', 'opencode', 'codex']) {
   return {
     available: agentList,
     default: agentList[0],
@@ -321,10 +292,10 @@ export interface FixtureOverrides {
 }
 
 export async function mockApiRoutes(
-  page: import("@playwright/test").Page,
+  page: import('@playwright/test').Page,
   overrides: FixtureOverrides = {},
 ) {
-  const agentList = overrides.agents || ["claude", "opencode", "codex"];
+  const agentList = overrides.agents || ['claude', 'opencode', 'codex'];
   const cache = new Map<string, unknown>();
 
   function getOrGenerate(key: string, generator: () => unknown): unknown {
@@ -332,56 +303,44 @@ export async function mockApiRoutes(
     return cache.get(key);
   }
 
-  await page.route("**/api/**", async (route) => {
+  await page.route('**/api/**', async (route) => {
     const url = new URL(route.request().url());
-    const path = url.pathname.replace("/api/", "");
-    const agent = url.searchParams.get("agent") || "claude";
+    const path = url.pathname.replace('/api/', '');
+    const agent = url.searchParams.get('agent') || 'claude';
 
     switch (path) {
-      case "agents":
+      case 'agents':
         if (overrides.emptyAgents) {
           await route.fulfill({ json: generateAgentsResponse([]) });
         } else {
-          await route.fulfill({
-            json: getOrGenerate("agents", () =>
-              generateAgentsResponse(agentList),
-            ),
-          });
+          await route.fulfill({ json: getOrGenerate('agents', () => generateAgentsResponse(agentList)) });
         }
         break;
 
-      case "daily":
+      case 'daily':
         await route.fulfill({
-          json: getOrGenerate(`daily:${agent}`, () =>
-            generateDailyResponse(agent),
-          ),
+          json: getOrGenerate(`daily:${agent}`, () => generateDailyResponse(agent)),
         });
         break;
 
-      case "projects":
+      case 'projects':
         await route.fulfill({
-          json: getOrGenerate(`projects:${agent}`, () =>
-            generateProjectsResponse(agent),
-          ),
+          json: getOrGenerate(`projects:${agent}`, () => generateProjectsResponse(agent)),
         });
         break;
 
-      case "blocks":
+      case 'blocks':
         if (overrides.noBlocks) {
           await route.fulfill({ json: { blocks: [] } });
         } else {
           await route.fulfill({
-            json: getOrGenerate(`blocks:${agent}`, () =>
-              generateBlocksResponse(agent),
-            ),
+            json: getOrGenerate(`blocks:${agent}`, () => generateBlocksResponse(agent)),
           });
         }
         break;
 
-      case "analytics": {
-        const analytics = getOrGenerate(`analytics:${agent}`, () =>
-          generateAnalyticsResponse(agent),
-        );
+      case 'analytics': {
+        const analytics = getOrGenerate(`analytics:${agent}`, () => generateAnalyticsResponse(agent));
         if (analytics) {
           await route.fulfill({ json: analytics });
         } else {
@@ -390,14 +349,7 @@ export async function mockApiRoutes(
             json: {
               codeChangeTrend: [],
               toolUsageDistribution: [],
-              productivityKPIs: {
-                avgLinesPerEdit: 0,
-                filesModifiedPerDay: 0,
-                addDeleteRatio: 0,
-                totalEdits: 0,
-                totalFilesModified: 0,
-                activeDaysWithEdits: 0,
-              },
+              productivityKPIs: { avgLinesPerEdit: 0, filesModifiedPerDay: 0, addDeleteRatio: 0, totalEdits: 0, totalFilesModified: 0, activeDaysWithEdits: 0 },
               toolCallTrend: [],
             },
           });

--- a/src/__tests__/client/apiClient.test.ts
+++ b/src/__tests__/client/apiClient.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchAnalytics, fetchBlocks, fetchDaily, fetchProjects } from '../../client/api/client.js';
+
+describe('dashboard refresh requests', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('bypasses the server cache for every dashboard data source', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await Promise.all([
+      fetchDaily('pi', true),
+      fetchProjects('pi', true),
+      fetchBlocks('pi', 'D:\\work\\api', true),
+      fetchAnalytics('pi', 'D:\\work\\api', true),
+    ]);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/daily?agent=pi&refresh=1');
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/projects?agent=pi&refresh=1');
+    expect(fetchMock).toHaveBeenNthCalledWith(3, '/api/blocks?agent=pi&project=D%3A%5Cwork%5Capi&refresh=1');
+    expect(fetchMock).toHaveBeenNthCalledWith(4, '/api/analytics?agent=pi&project=D%3A%5Cwork%5Capi&refresh=1');
+  });
+});

--- a/src/__tests__/client/formatters.test.ts
+++ b/src/__tests__/client/formatters.test.ts
@@ -64,4 +64,10 @@ describe('formatProjectName', () => {
     const all = ['dir1/dashboard', 'dir2/other'];
     expect(formatProjectName('dir1/dashboard', all)).toBe('dashboard');
   });
+
+  it('uses parent prefixes for Windows paths with duplicate directory names', () => {
+    const all = ['D:\\work\\api', 'D:\\archive\\api'];
+    expect(formatProjectName('D:\\work\\api', all)).toBe('work/api');
+    expect(formatProjectName('D:\\archive\\api', all)).toBe('archive/api');
+  });
 });

--- a/src/__tests__/server/forceRefreshRoutes.test.ts
+++ b/src/__tests__/server/forceRefreshRoutes.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+
+const mocks = vi.hoisted(() => ({
+  piDaily: vi.fn(() => ({ daily: [], totals: { inputTokens: 1, outputTokens: 2, cacheCreationTokens: 3, cacheReadTokens: 4, totalTokens: 10, totalCost: 0.5 } })),
+  piProjects: vi.fn(() => ({ projects: {} })),
+  piBlocks: vi.fn(() => ({ blocks: [] })),
+  claudeToolCalls: vi.fn(() => []),
+  computeAnalytics: vi.fn(() => ({
+    codeChangeTrend: [],
+    toolUsageDistribution: [],
+    productivityKPIs: { avgLinesPerEdit: 0, filesModifiedPerDay: 0, addDeleteRatio: 0, totalEdits: 0, totalFilesModified: 0, activeDaysWithEdits: 0 },
+    toolCallTrend: [],
+  })),
+}));
+
+vi.mock('../../server/piParser.js', () => ({
+  getDailyResponse: mocks.piDaily,
+  getProjectsResponse: mocks.piProjects,
+  getBlocksResponse: mocks.piBlocks,
+}));
+vi.mock('../../server/codexParser.js', () => ({ getDailyResponse: vi.fn(), getProjectsResponse: vi.fn(), getBlocksResponse: vi.fn() }));
+vi.mock('../../server/openclawParser.js', () => ({ getDailyResponse: vi.fn(), getProjectsResponse: vi.fn(), getBlocksResponse: vi.fn() }));
+vi.mock('../../server/opencodeParser.js', () => ({ getDailyResponse: vi.fn(), getProjectsResponse: vi.fn(), getBlocksResponse: vi.fn() }));
+vi.mock('../../server/claudeJsonlParser.js', () => ({ getDailyResponse: vi.fn(), getProjectsResponse: vi.fn(), getBlocksResponse: vi.fn() }));
+vi.mock('../../server/analyticsParser.js', () => ({
+  extractClaudeToolCalls: mocks.claudeToolCalls,
+  extractOpenClawToolCalls: vi.fn(),
+  computeAnalytics: mocks.computeAnalytics,
+}));
+
+const { cache } = await import('../../server/cache.js');
+const { getDaily } = await import('../../server/routes/daily.js');
+const { getProjects } = await import('../../server/routes/projects.js');
+const { getBlocks } = await import('../../server/routes/blocks.js');
+const { getAnalytics } = await import('../../server/routes/analytics.js');
+
+function request(agent: string): Request {
+  return { query: { agent, refresh: '1' } } as unknown as Request;
+}
+
+function response() {
+  const res = { json: vi.fn(), status: vi.fn() };
+  res.status.mockReturnValue(res);
+  return res as unknown as Response & { json: ReturnType<typeof vi.fn> };
+}
+
+describe('forced dashboard refreshes', () => {
+  beforeEach(() => {
+    cache.clear();
+    vi.clearAllMocks();
+  });
+
+  it('recomputes daily, projects, and blocks instead of serving their fresh cache entries', async () => {
+    cache.set('daily:pi', { cached: true });
+    cache.set('projects:pi', { cached: true });
+    cache.set('blocks:pi:all', { cached: true });
+    const dailyRes = response();
+    const projectsRes = response();
+    const blocksRes = response();
+
+    await getDaily(request('pi'), dailyRes);
+    await getProjects(request('pi'), projectsRes);
+    await getBlocks(request('pi'), blocksRes);
+
+    expect(mocks.piDaily).toHaveBeenCalledOnce();
+    expect(mocks.piProjects).toHaveBeenCalledOnce();
+    expect(mocks.piBlocks).toHaveBeenCalledOnce();
+    expect(dailyRes.json).toHaveBeenCalledWith(expect.objectContaining({ totals: expect.any(Object) }));
+    expect(projectsRes.json).toHaveBeenCalledWith({ projects: {} });
+    expect(blocksRes.json).toHaveBeenCalledWith({ blocks: [] });
+  });
+
+  it('recomputes analytics instead of serving its fresh cache entry', async () => {
+    cache.set('analytics:claude:all', { cached: true });
+    const analyticsRes = response();
+
+    await getAnalytics(request('claude'), analyticsRes);
+
+    expect(mocks.claudeToolCalls).toHaveBeenCalledOnce();
+    expect(mocks.computeAnalytics).toHaveBeenCalledOnce();
+    expect(analyticsRes.json).toHaveBeenCalledWith(expect.objectContaining({ productivityKPIs: expect.any(Object) }));
+  });
+});

--- a/src/__tests__/server/piParser.test.ts
+++ b/src/__tests__/server/piParser.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { normalizePiProjectPath } from '../../server/piParser.js';
+
+describe('normalizePiProjectPath', () => {
+  it('keeps distinct absolute paths distinct while removing only trailing separators', () => {
+    expect(normalizePiProjectPath('D:\\work\\api\\')).toBe('D:\\work\\api');
+    expect(normalizePiProjectPath('D:\\archive\\api')).toBe('D:\\archive\\api');
+    expect(normalizePiProjectPath('/work/api/')).toBe('/work/api');
+  });
+});

--- a/src/__tests__/server/usageSupport.test.ts
+++ b/src/__tests__/server/usageSupport.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { hasUsageDataSource } from '../../server/index.js';
+
+describe('hasUsageDataSource', () => {
+  it.each(['claude', 'codex', 'openclaw', 'opencode', 'pi'])('accepts a %s-only installation', (availableAgent) => {
+    expect(hasUsageDataSource({
+      claude: availableAgent === 'claude',
+      codex: availableAgent === 'codex',
+      openclaw: availableAgent === 'openclaw',
+      opencode: availableAgent === 'opencode',
+      pi: availableAgent === 'pi',
+    })).toBe(true);
+  });
+
+  it('rejects an installation with no supported usage source', () => {
+    expect(hasUsageDataSource({ claude: false, codex: false, openclaw: false, opencode: false, pi: false })).toBe(false);
+  });
+});

--- a/src/client/api/client.ts
+++ b/src/client/api/client.ts
@@ -28,8 +28,8 @@ function qs(agent: string, extra?: Record<string, string>): string {
   return parts.length > 0 ? '?' + parts.join('&') : '';
 }
 
-export async function fetchDaily(agent = 'claude'): Promise<DailyResponse> {
-  const res = await fetch(`${BASE}/daily${qs(agent)}`);
+export async function fetchDaily(agent = 'claude', refresh = false): Promise<DailyResponse> {
+  const res = await fetch(`${BASE}/daily${qs(agent, refresh ? { refresh: '1' } : undefined)}`);
   if (!res.ok) {
     throw new Error(`Failed to fetch daily data: ${res.status} ${res.statusText}`);
   }
@@ -52,24 +52,24 @@ export async function fetchSession(agent = 'claude'): Promise<SessionResponse> {
   return res.json();
 }
 
-export async function fetchProjects(agent = 'claude'): Promise<ProjectsResponse> {
-  const res = await fetch(`${BASE}/projects${qs(agent)}`);
+export async function fetchProjects(agent = 'claude', refresh = false): Promise<ProjectsResponse> {
+  const res = await fetch(`${BASE}/projects${qs(agent, refresh ? { refresh: '1' } : undefined)}`);
   if (!res.ok) {
     throw new Error(`Failed to fetch projects data: ${res.status} ${res.statusText}`);
   }
   return res.json();
 }
 
-export async function fetchBlocks(agent = 'claude', project = ''): Promise<BlocksResponse> {
-  const res = await fetch(`${BASE}/blocks${qs(agent, project ? { project } : undefined)}`);
+export async function fetchBlocks(agent = 'claude', project = '', refresh = false): Promise<BlocksResponse> {
+  const res = await fetch(`${BASE}/blocks${qs(agent, { ...(project ? { project } : {}), ...(refresh ? { refresh: '1' } : {}) })}`);
   if (!res.ok) {
     throw new Error(`Failed to fetch blocks data: ${res.status} ${res.statusText}`);
   }
   return res.json();
 }
 
-export async function fetchAnalytics(agent = 'claude', project = ''): Promise<AnalyticsResponse> {
-  const res = await fetch(`${BASE}/analytics${qs(agent, project ? { project } : undefined)}`);
+export async function fetchAnalytics(agent = 'claude', project = '', refresh = false): Promise<AnalyticsResponse> {
+  const res = await fetch(`${BASE}/analytics${qs(agent, { ...(project ? { project } : {}), ...(refresh ? { refresh: '1' } : {}) })}`);
   if (!res.ok) {
     throw new Error(`Failed to fetch analytics: ${res.status} ${res.statusText}`);
   }

--- a/src/client/components/Dashboard.tsx
+++ b/src/client/components/Dashboard.tsx
@@ -190,8 +190,8 @@ export function Dashboard() {
   const [agentsInfo, setAgentsInfo] = useState<AgentsResponse | null>(null);
   const [agentsLoading, setAgentsLoading] = useState(true);
 
-  const [agent, setAgent] = useLocalStorageState<'claude' | 'codex' | 'openclaw' | 'opencode'>('dashboard_agent', 'claude');
-  const isCodex = agent === 'codex' || agent === 'opencode';
+  const [agent, setAgent] = useLocalStorageState<'claude' | 'codex' | 'openclaw' | 'opencode' | 'pi'>('dashboard_agent', 'claude');
+  const isCodex = agent === 'codex' || agent === 'opencode' || agent === 'pi';
 
   const [timeRange, setTimeRange] = useLocalStorageState<TimeRangeKey>('dashboard_timeRange', '30d');
   const [project, setProject] = useLocalStorageState('dashboard_project', '');
@@ -212,7 +212,7 @@ export function Dashboard() {
         setAgentsInfo(info);
         // Fallback stored agent if unavailable
         if (info.available.length > 0 && !info.available.includes(agent)) {
-          setAgent(info.default as 'claude' | 'codex' | 'openclaw' | 'opencode');
+          setAgent(info.default as 'claude' | 'codex' | 'openclaw' | 'opencode' | 'pi');
         }
       })
       .catch(() => {})
@@ -227,7 +227,7 @@ export function Dashboard() {
   const analyticsData = useCcusageData(useCallback(() => fetchAnalytics(agent, project), [agent, project]));
   const [metric, setMetric] = useLocalStorageState<MetricMode>('dashboard_metric', 'tokens');
 
-  const handleAgentChange = (a: 'claude' | 'codex' | 'openclaw' | 'opencode') => {
+  const handleAgentChange = (a: 'claude' | 'codex' | 'openclaw' | 'opencode' | 'pi') => {
     setAgent(a);
     setProject('');
   };
@@ -489,6 +489,11 @@ export function Dashboard() {
       activeColor: 'text-amber-600',
       icon: <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" /></svg>,
     },
+    pi: {
+      label: 'Pi',
+      activeColor: 'text-violet-600',
+      icon: <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23-.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" /></svg>,
+    },
   };
 
   const renderAgentSwitcher = () => {
@@ -501,7 +506,7 @@ export function Dashboard() {
           return (
             <button
               key={a}
-              onClick={() => handleAgentChange(a as 'claude' | 'codex' | 'openclaw' | 'opencode')}
+              onClick={() => handleAgentChange(a as 'claude' | 'codex' | 'openclaw' | 'opencode' | 'pi')}
               className={`flex items-center gap-2 px-5 py-2.5 rounded-lg text-[13px] font-bold tracking-wide transition-all duration-200 ${isActive
                 ? `bg-white ${cfg.activeColor} shadow-[0_1px_3px_rgba(0,0,0,0.1)] ring-1 ring-stone-900/5`
                 : 'text-stone-500 hover:text-stone-800 hover:bg-stone-200/50'

--- a/src/client/components/Dashboard.tsx
+++ b/src/client/components/Dashboard.tsx
@@ -191,7 +191,7 @@ export function Dashboard() {
   const [agentsLoading, setAgentsLoading] = useState(true);
 
   const [agent, setAgent] = useLocalStorageState<'claude' | 'codex' | 'openclaw' | 'opencode' | 'pi'>('dashboard_agent', 'claude');
-  const isCodex = agent === 'codex' || agent === 'opencode' || agent === 'pi';
+  const hasNoAnalytics = agent === 'codex' || agent === 'opencode' || agent === 'pi';
 
   const [timeRange, setTimeRange] = useLocalStorageState<TimeRangeKey>('dashboard_timeRange', '30d');
   const [project, setProject] = useLocalStorageState('dashboard_project', '');
@@ -830,7 +830,7 @@ export function Dashboard() {
       </div>
 
       {/* Section: Code Analytics (Claude Code & OpenClaw only) */}
-      {!isCodex && analyticsData.data && (
+      {!hasNoAnalytics && analyticsData.data && (
         <AnalyticsSection analytics={analyticsData.data} timeRange={timeRange} />
       )}
 

--- a/src/client/components/Dashboard.tsx
+++ b/src/client/components/Dashboard.tsx
@@ -221,10 +221,10 @@ export function Dashboard() {
 
   const showAgentSwitcher = (agentsInfo?.available.length ?? 0) > 1;
 
-  const dailyData = useCcusageData(useCallback(() => fetchDaily(agent), [agent]));
-  const projectsData = useCcusageData(useCallback(() => fetchProjects(agent), [agent]));
-  const blocksData = useCcusageData(useCallback(() => fetchBlocks(agent, project), [agent, project]));
-  const analyticsData = useCcusageData(useCallback(() => fetchAnalytics(agent, project), [agent, project]));
+  const dailyData = useCcusageData(useCallback((refresh = false) => fetchDaily(agent, refresh), [agent]));
+  const projectsData = useCcusageData(useCallback((refresh = false) => fetchProjects(agent, refresh), [agent]));
+  const blocksData = useCcusageData(useCallback((refresh = false) => fetchBlocks(agent, project, refresh), [agent, project]));
+  const analyticsData = useCcusageData(useCallback((refresh = false) => fetchAnalytics(agent, project, refresh), [agent, project]));
 
   // 手动刷新所有数据源
   const handleRefreshAll = useCallback(() => {

--- a/src/client/components/Dashboard.tsx
+++ b/src/client/components/Dashboard.tsx
@@ -225,6 +225,19 @@ export function Dashboard() {
   const projectsData = useCcusageData(useCallback(() => fetchProjects(agent), [agent]));
   const blocksData = useCcusageData(useCallback(() => fetchBlocks(agent, project), [agent, project]));
   const analyticsData = useCcusageData(useCallback(() => fetchAnalytics(agent, project), [agent, project]));
+
+  // 手动刷新所有数据源
+  const handleRefreshAll = useCallback(() => {
+    dailyData.refetch();
+    projectsData.refetch();
+    blocksData.refetch();
+    analyticsData.refetch();
+  }, [dailyData.refetch, projectsData.refetch, blocksData.refetch, analyticsData.refetch]);
+
+  // 格式化上次更新时间（HH:mm:ss）
+  const lastUpdatedStr = dailyData.lastUpdated
+    ? dailyData.lastUpdated.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+    : null;
   const [metric, setMetric] = useLocalStorageState<MetricMode>('dashboard_metric', 'tokens');
 
   const handleAgentChange = (a: 'claude' | 'codex' | 'openclaw' | 'opencode' | 'pi') => {
@@ -528,7 +541,19 @@ export function Dashboard() {
           <div className="flex flex-col gap-1.5">
             <h1 className="text-3xl font-extrabold tracking-tight text-stone-900">TokenDash</h1>
           </div>
-          {showAgentSwitcher && renderAgentSwitcher()}
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleRefreshAll}
+              disabled={dailyData.loading}
+              title="刷新数据"
+              className="flex items-center justify-center w-8 h-8 rounded-lg text-stone-400 hover:text-indigo-600 hover:bg-indigo-50 transition-colors disabled:opacity-40"
+            >
+              <svg className={`w-4 h-4 ${dailyData.loading ? 'animate-spin' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
+            {showAgentSwitcher && renderAgentSwitcher()}
+          </div>
         </div>
         <div className="skeleton h-8 w-48 rounded-lg mb-2" />
         <div className="skeleton h-4 w-72 rounded-lg mb-8" />
@@ -544,7 +569,19 @@ export function Dashboard() {
         <div className="flex flex-col gap-1.5">
           <h1 className="text-3xl font-extrabold tracking-tight text-stone-900">TokenDash</h1>
         </div>
-        {showAgentSwitcher && renderAgentSwitcher()}
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleRefreshAll}
+            disabled={dailyData.loading}
+            title="刷新数据"
+            className="flex items-center justify-center w-8 h-8 rounded-lg text-stone-400 hover:text-indigo-600 hover:bg-indigo-50 transition-colors disabled:opacity-40"
+          >
+            <svg className={`w-4 h-4 ${dailyData.loading ? 'animate-spin' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+          </button>
+          {showAgentSwitcher && renderAgentSwitcher()}
+        </div>
       </div>
       <div className="rounded-2xl bg-red-50 border border-red-200/60 p-5"><div className="text-red-600 text-sm font-medium">{dailyData.error}</div></div>
     </div>
@@ -563,7 +600,25 @@ export function Dashboard() {
               Monitor token consumption, costs, and cache efficiency for your AI coding assistants.
             </p>
           </div>
-          {showAgentSwitcher && renderAgentSwitcher()}
+          <div className="flex items-center gap-3">
+            {/* 自动刷新状态 + 手动刷新按钮 */}
+            <div className="flex items-center gap-2">
+              {lastUpdatedStr && (
+                <span className="text-[11px] font-medium text-stone-400">更新于 {lastUpdatedStr}</span>
+              )}
+              <button
+                onClick={handleRefreshAll}
+                disabled={dailyData.loading}
+                title="刷新数据（每 60 秒自动刷新）"
+                className="flex items-center justify-center w-8 h-8 rounded-lg text-stone-400 hover:text-indigo-600 hover:bg-indigo-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <svg className={`w-4 h-4 ${dailyData.loading ? 'animate-spin' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+              </button>
+            </div>
+            {showAgentSwitcher && renderAgentSwitcher()}
+          </div>
         </div>
 
         <div className="flex flex-col gap-4">

--- a/src/client/hooks/useCcusageData.ts
+++ b/src/client/hooks/useCcusageData.ts
@@ -2,18 +2,18 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 
 const DEFAULT_INTERVAL_MS = 60_000; // 60 秒自动刷新
 
-export function useCcusageData<T>(fetcher: () => Promise<T>, intervalMs: number = DEFAULT_INTERVAL_MS) {
+export function useCcusageData<T>(fetcher: (refresh?: boolean) => Promise<T>, intervalMs: number = DEFAULT_INTERVAL_MS) {
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (refresh = false) => {
     setLoading(true);
     setError(null);
     try {
-      const result = await fetcher();
+      const result = await fetcher(refresh);
       setData(result);
       setLastUpdated(new Date());
     } catch (err) {
@@ -31,11 +31,13 @@ export function useCcusageData<T>(fetcher: () => Promise<T>, intervalMs: number 
   // 定时自动刷新
   useEffect(() => {
     if (intervalMs <= 0) return;
-    timerRef.current = setInterval(fetchData, intervalMs);
+    timerRef.current = setInterval(() => { void fetchData(true); }, intervalMs);
     return () => {
       if (timerRef.current) clearInterval(timerRef.current);
     };
   }, [fetchData, intervalMs]);
 
-  return { data, loading, error, refetch: fetchData, lastUpdated };
+  const refetch = useCallback(() => fetchData(true), [fetchData]);
+
+  return { data, loading, error, refetch, lastUpdated };
 }

--- a/src/client/hooks/useCcusageData.ts
+++ b/src/client/hooks/useCcusageData.ts
@@ -1,9 +1,13 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
-export function useCcusageData<T>(fetcher: () => Promise<T>) {
+const DEFAULT_INTERVAL_MS = 60_000; // 60 秒自动刷新
+
+export function useCcusageData<T>(fetcher: () => Promise<T>, intervalMs: number = DEFAULT_INTERVAL_MS) {
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -11,6 +15,7 @@ export function useCcusageData<T>(fetcher: () => Promise<T>) {
     try {
       const result = await fetcher();
       setData(result);
+      setLastUpdated(new Date());
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
@@ -18,9 +23,19 @@ export function useCcusageData<T>(fetcher: () => Promise<T>) {
     }
   }, [fetcher]);
 
+  // 首次加载 + fetcher 变化时重新拉取
   useEffect(() => {
     fetchData();
   }, [fetchData]);
 
-  return { data, loading, error, refetch: fetchData };
+  // 定时自动刷新
+  useEffect(() => {
+    if (intervalMs <= 0) return;
+    timerRef.current = setInterval(fetchData, intervalMs);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [fetchData, intervalMs]);
+
+  return { data, loading, error, refetch: fetchData, lastUpdated };
 }

--- a/src/client/utils/formatters.ts
+++ b/src/client/utils/formatters.ts
@@ -35,7 +35,7 @@ export function formatPercent(n: number): string {
 export function formatProjectName(project: string, allProjects?: string[]): string {
   if (!project) return '';
 
-  const getParts = (p: string) => p.split('/').filter(Boolean);
+  const getParts = (p: string) => p.split(/[\\/]/).filter(Boolean);
   const parts = getParts(project);
   if (parts.length === 0) return project;
 

--- a/src/server/agentDetection.ts
+++ b/src/server/agentDetection.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { isPiAccessible } from './piParser.js';
 
 const CLAUDE_PROJECTS_DIR = join(homedir(), '.claude', 'projects');
 const CODEX_SESSIONS_DIR = join(homedir(), '.codex', 'sessions');
@@ -23,10 +24,11 @@ export function isOpencodeAvailable(): boolean {
   return existsSync(join(homedir(), '.local', 'share', 'opencode', 'opencode.db'));
 }
 
-export function detectAvailableAgents(): { claude: boolean; codex: boolean; opencode: boolean } {
+export function detectAvailableAgents(): { claude: boolean; codex: boolean; opencode: boolean; pi: boolean } {
   return {
     claude: isClaudeCodeAvailable(),
     codex: isCodexAvailable(),
     opencode: isOpencodeAvailable(),
+    pi: isPiAccessible(),
   };
 }

--- a/src/server/agentDetection.ts
+++ b/src/server/agentDetection.ts
@@ -1,6 +1,8 @@
 import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { isOpenClawAccessible } from './openclawParser.js';
+import { isOpencodeAccessible } from './opencodeParser.js';
 import { isPiAccessible } from './piParser.js';
 
 const CLAUDE_PROJECTS_DIR = join(homedir(), '.claude', 'projects');
@@ -21,13 +23,22 @@ export function isCodexAvailable(): boolean {
 }
 
 export function isOpencodeAvailable(): boolean {
-  return existsSync(join(homedir(), '.local', 'share', 'opencode', 'opencode.db'));
+  return isOpencodeAccessible();
 }
 
-export function detectAvailableAgents(): { claude: boolean; codex: boolean; opencode: boolean; pi: boolean } {
+export interface AvailableAgents {
+  claude: boolean;
+  codex: boolean;
+  openclaw: boolean;
+  opencode: boolean;
+  pi: boolean;
+}
+
+export function detectAvailableAgents(): AvailableAgents {
   return {
     claude: isClaudeCodeAvailable(),
     codex: isCodexAvailable(),
+    openclaw: isOpenClawAccessible(),
     opencode: isOpencodeAvailable(),
     pi: isPiAccessible(),
   };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -311,3 +311,13 @@ async function main() {
 }
 
 export { main };
+
+// 仅当文件被直接执行时调用（tsx watch / node index.js）；
+// bin/tokendash.js 通过 import { main } 自行调用，不触发此处。
+import { pathToFileURL } from 'node:url';
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error('Fatal error:', error);
+    process.exit(1);
+  });
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -90,14 +90,15 @@ function parseCliArgs(): CliArgs {
 async function ensureUsageSupportAvailable(): Promise<boolean> {
   try {
     const agents = detectAvailableAgents();
-    if (!agents.claude && !agents.codex) {
+    if (!agents.claude && !agents.codex && !agents.pi) {
       console.error('Error: No AI coding assistant data found.');
-      console.error('\nDetails: Could not find Claude Code (~/.claude/projects/) or Codex (~/.codex/sessions/) data.');
-      console.error('Please install at least one of: Claude Code or Codex CLI.');
+      console.error('\nDetails: Could not find Claude Code (~/.claude/projects/), Codex (~/.codex/sessions/) or Pi (~/.pi/agent/sessions/) data.');
+      console.error('Please install at least one of: Claude Code, Codex CLI or Pi.');
       return false;
     }
     if (agents.claude) console.log('  ✓ Claude Code detected');
     if (agents.codex) console.log('  ✓ Codex detected');
+    if (agents.pi) console.log('  ✓ Pi detected');
     return true;
   } catch (error) {
     console.error('Error: failed to detect available AI coding assistants');
@@ -314,8 +315,10 @@ export { main };
 
 // 仅当文件被直接执行时调用（tsx watch / node index.js）；
 // bin/tokendash.js 通过 import { main } 自行调用，不触发此处。
+// process.argv[1] 在部分运行时（如 REPL、嵌入式调用）可能为空，先守卫再转换。
 import { pathToFileURL } from 'node:url';
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+const entrypoint = process.argv[1];
+if (entrypoint && import.meta.url === pathToFileURL(entrypoint).href) {
   main().catch((error) => {
     console.error('Fatal error:', error);
     process.exit(1);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,7 +5,7 @@ import type { Server } from 'node:http';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { basename, dirname, join, resolve } from 'node:path';
 import { registerApiRoutes } from './routes/api.js';
-import { detectAvailableAgents } from './agentDetection.js';
+import { detectAvailableAgents, type AvailableAgents } from './agentDetection.js';
 
 interface CliArgs {
   port?: number;
@@ -87,17 +87,23 @@ function parseCliArgs(): CliArgs {
   return result;
 }
 
+export function hasUsageDataSource(agents: AvailableAgents): boolean {
+  return Object.values(agents).some(Boolean);
+}
+
 async function ensureUsageSupportAvailable(): Promise<boolean> {
   try {
     const agents = detectAvailableAgents();
-    if (!agents.claude && !agents.codex && !agents.pi) {
+    if (!hasUsageDataSource(agents)) {
       console.error('Error: No AI coding assistant data found.');
-      console.error('\nDetails: Could not find Claude Code (~/.claude/projects/), Codex (~/.codex/sessions/) or Pi (~/.pi/agent/sessions/) data.');
-      console.error('Please install at least one of: Claude Code, Codex CLI or Pi.');
+      console.error('\nDetails: Could not find Claude Code, Codex, OpenClaw, OpenCode, or Pi usage data.');
+      console.error('Please install at least one supported AI coding assistant.');
       return false;
     }
     if (agents.claude) console.log('  ✓ Claude Code detected');
     if (agents.codex) console.log('  ✓ Codex detected');
+    if (agents.openclaw) console.log('  ✓ OpenClaw detected');
+    if (agents.opencode) console.log('  ✓ OpenCode detected');
     if (agents.pi) console.log('  ✓ Pi detected');
     return true;
   } catch (error) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import type { Express } from 'express';
 import { existsSync, readFileSync } from 'node:fs';
 import type { Server } from 'node:http';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { basename, dirname, join, resolve } from 'node:path';
 import { registerApiRoutes } from './routes/api.js';
 import { detectAvailableAgents } from './agentDetection.js';
@@ -316,7 +316,6 @@ export { main };
 // 仅当文件被直接执行时调用（tsx watch / node index.js）；
 // bin/tokendash.js 通过 import { main } 自行调用，不触发此处。
 // process.argv[1] 在部分运行时（如 REPL、嵌入式调用）可能为空，先守卫再转换。
-import { pathToFileURL } from 'node:url';
 const entrypoint = process.argv[1];
 if (entrypoint && import.meta.url === pathToFileURL(entrypoint).href) {
   main().catch((error) => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -135,7 +135,28 @@ function listen(app: Express, port: number): Promise<Server> {
   });
 }
 
-async function listenWithPortFallback(app: Express, preferredPort: number): Promise<{ server: Server; port: number; usedFallback: boolean }> {
+async function listenWithPortFallback(app: Express, preferredPort: number, allowFallback: boolean): Promise<{ server: Server; port: number; usedFallback: boolean }> {
+  // 开发模式下 Vite 代理固定指向首选端口，若静默回退到其他端口，
+  // 前端请求会被代理到错误/残留进程导致页面永久加载；故 dev 下
+  // 端口被占用直接报错，不做回退。生产模式无此约束，保留回退。
+  if (!allowFallback) {
+    try {
+      const server = await listen(app, preferredPort);
+      return { server, port: preferredPort, usedFallback: false };
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === 'EADDRINUSE') {
+        throw new Error(
+          `Port ${preferredPort} is already in use.\n` +
+          'In development mode tokendash does not fall back to another port, because the Vite\n' +
+          'dev proxy is fixed to this port; falling back would leave the dashboard loading forever.\n' +
+          `Free port ${preferredPort} (kill the process using it) and retry.`,
+        );
+      }
+      throw error;
+    }
+  }
+
   let port = preferredPort;
 
   for (let attempt = 0; attempt < 20; attempt++, port++) {
@@ -270,8 +291,12 @@ async function main() {
     process.exit(1);
   }
 
+  const isProduction = import.meta.url.includes('dist/');
   const app = createApp(preferredPort);
-  const { server, port, usedFallback } = await listenWithPortFallback(app, preferredPort);
+  const { server, port, usedFallback } = await listenWithPortFallback(app, preferredPort, isProduction).catch((error) => {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  });
 
   if (usedFallback) {
     console.warn(`tokendash detected that port ${preferredPort} is already in use, switched to http://127.0.0.1:${port}`);
@@ -279,7 +304,6 @@ async function main() {
 
   console.log(`tokendash running on http://127.0.0.1:${port}`);
   console.log(`API available at http://127.0.0.1:${port}/api`);
-  const isProduction = import.meta.url.includes('dist/');
   if (isProduction) {
     console.log('Serving production build');
   } else {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -310,18 +310,26 @@ async function main() {
     console.log('Development mode - use "npm run dev" for full dev experience');
   }
 
-  // Open browser if requested
+  // Open browser if requested.
+  // 开发模式下前端由 Vite 在 5173 端口提供，自动打开 API 端口（3456）并无意义；
+  // 且在 concurrently（npm run dev）下 open 派生的子进程会继承被管道化的 stdio，
+  // 造成管道死锁使服务进程挂起、页面一直加载。故仅生产模式自动打开浏览器，
+  // dev 模式改为提示 Vite 开发服务器地址。
   if (shouldOpenBrowser) {
-    // Small delay to ensure server is ready
-    setTimeout(async () => {
-      console.log('Opening dashboard in your browser...');
-      try {
-        const { default: open } = await import('open');
-        await open(`http://127.0.0.1:${port}`);
-      } catch (err: any) {
-        console.warn('Could not open browser:', err.message);
-      }
-    }, 100);
+    if (isProduction) {
+      // Small delay to ensure server is ready
+      setTimeout(async () => {
+        console.log('Opening dashboard in your browser...');
+        try {
+          const { default: open } = await import('open');
+          await open(`http://127.0.0.1:${port}`);
+        } catch (err: any) {
+          console.warn('Could not open browser:', err.message);
+        }
+      }, 100);
+    } else {
+      console.log('Development mode: open http://localhost:5173/ in your browser (Vite dev server).');
+    }
   } else {
     console.log('Browser auto-open disabled (--no-open)');
   }

--- a/src/server/piParser.ts
+++ b/src/server/piParser.ts
@@ -226,11 +226,10 @@ function getHourKey(ts: string, tz: string): string {
   return local.toISOString().slice(0, 13).replace('T', ' ') + ':00';
 }
 
-/** 从 cwd 提取项目名（兼容 Windows 反斜杠和 Unix 斜杠路径）。 */
-function extractProjectName(cwd: string): string {
+/** Keep the full working-directory path so same-named projects do not merge. */
+export function normalizePiProjectPath(cwd: string): string {
   if (!cwd) return 'unknown';
-  const parts = cwd.replace(/[\\/]+$/, '').split(/[\\/]/);
-  return parts[parts.length - 1] || 'unknown';
+  return cwd.replace(/[\\/]+$/, '') || 'unknown';
 }
 
 // ---------------------------------------------------------------------------
@@ -296,7 +295,7 @@ function groupSessions(
   const grouped = new Map<string, AggregateBucket>();
 
   for (const session of sessions) {
-    const projectName = extractProjectName(session.cwd);
+    const projectName = normalizePiProjectPath(session.cwd);
     if (projectFilter && projectName !== projectFilter) continue;
 
     for (const ev of session.tokenEvents) {
@@ -361,7 +360,7 @@ export function getProjectsResponse(options?: { timezone?: string }): ProjectsRe
   const projectDaily = new Map<string, Map<string, AggregateBucket>>();
 
   for (const session of sessions) {
-    const projectName = extractProjectName(session.cwd);
+    const projectName = normalizePiProjectPath(session.cwd);
     if (!projectDaily.has(projectName)) projectDaily.set(projectName, new Map());
     const dailyMap = projectDaily.get(projectName)!;
 

--- a/src/server/piParser.ts
+++ b/src/server/piParser.ts
@@ -1,0 +1,416 @@
+import { readFileSync, readdirSync, statSync, accessSync, constants } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import type { DailyEntry, DailyResponse, ProjectsResponse, BlockEntry, BlocksResponse, ModelBreakdown } from '../shared/types.js';
+import { buildUsageFileIndex } from './usageFileIndex.js';
+
+// ---------------------------------------------------------------------------
+// Pi JSONL 格式说明
+//
+// 会话文件位于 ~/.pi/agent/sessions/<project-dir-slug>/<timestamp>_<id>.jsonl
+// 每行 type 之一：
+//   session        — {"type":"session","id":"...","timestamp":"...","cwd":"D:\\file\\Zed"}
+//   model_change   — {"type":"model_change","provider":"amax","modelId":"qwen3.8-max-preview"}
+//   message        — role=assistant 时携带 usage 字段：
+//                    {input, output, cacheRead, cacheWrite, reasoning, totalTokens,
+//                     cost:{input,output,cacheRead,cacheWrite,total}}
+//                    以及 message.model / message.provider
+// ---------------------------------------------------------------------------
+
+const PI_INDEX_VERSION = 'pi-session-v1';
+const DEFAULT_TZ = 'Asia/Shanghai';
+
+// ---------------------------------------------------------------------------
+// 内部类型
+// ---------------------------------------------------------------------------
+
+interface PiTokenEvent {
+  timestamp: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+  cost: number;
+}
+
+interface PiSession {
+  id: string;
+  cwd: string;
+  createdAt: string;
+  tokenEvents: PiTokenEvent[];
+}
+
+interface TokenAccumulator {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+  cost: number;
+}
+
+interface AggregateBucket {
+  acc: TokenAccumulator;
+  models: Map<string, TokenAccumulator>;
+}
+
+// ---------------------------------------------------------------------------
+// 目录检测
+// ---------------------------------------------------------------------------
+
+function getPiSessionsDir(): string {
+  return join(homedir(), '.pi', 'agent', 'sessions');
+}
+
+export function isPiAccessible(): boolean {
+  try {
+    accessSync(getPiSessionsDir(), constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 文件扫描
+// ---------------------------------------------------------------------------
+
+export function scanPiSessions(): string[] {
+  const results: string[] = [];
+
+  function walk(dir: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry);
+      let st: ReturnType<typeof statSync>;
+      try {
+        st = statSync(full);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) {
+        walk(full);
+      } else if (entry.endsWith('.jsonl')) {
+        results.push(full);
+      }
+    }
+  }
+
+  walk(getPiSessionsDir());
+  return results.sort();
+}
+
+// ---------------------------------------------------------------------------
+// 单文件解析
+// ---------------------------------------------------------------------------
+
+export function parsePiSession(filepath: string): PiSession | null {
+  let content: string;
+  try {
+    content = readFileSync(filepath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  let sessionId = '';
+  let cwd = '';
+  let createdAt = '';
+  let currentModel = '';
+  const tokenEvents: PiTokenEvent[] = [];
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const type = obj.type as string;
+
+    if (type === 'session') {
+      sessionId = (obj.id as string) || '';
+      cwd = (obj.cwd as string) || '';
+      createdAt = (obj.timestamp as string) || '';
+      continue;
+    }
+
+    if (type === 'model_change') {
+      currentModel = (obj.modelId as string) || currentModel;
+      continue;
+    }
+
+    if (type !== 'message') continue;
+
+    const msg = obj.message as Record<string, unknown> | undefined;
+    if (!msg || msg.role !== 'assistant') continue;
+
+    const usage = msg.usage as Record<string, unknown> | undefined;
+    if (!usage) continue;
+
+    const totalTokens = (usage.totalTokens as number) || 0;
+    if (totalTokens === 0) continue;
+
+    const costObj = (usage.cost as Record<string, unknown>) || {};
+    const model = (msg.model as string) || currentModel || 'unknown';
+    const timestamp = (obj.timestamp as string) || '';
+
+    tokenEvents.push({
+      timestamp,
+      model,
+      inputTokens: (usage.input as number) || 0,
+      outputTokens: (usage.output as number) || 0,
+      cacheReadTokens: (usage.cacheRead as number) || 0,
+      cacheWriteTokens: (usage.cacheWrite as number) || 0,
+      totalTokens,
+      cost: (costObj.total as number) || 0,
+    });
+  }
+
+  if (!sessionId) return null;
+  return { id: sessionId, cwd, createdAt, tokenEvents };
+}
+
+// ---------------------------------------------------------------------------
+// 索引加载
+// ---------------------------------------------------------------------------
+
+function loadSessions(): PiSession[] {
+  const result = buildUsageFileIndex<PiSession | null, { path: string }>({
+    cacheName: 'pi-sessions',
+    parserVersion: PI_INDEX_VERSION,
+    files: scanPiSessions().map(path => ({ path })),
+    parseFile: file => parsePiSession(file.path),
+  });
+  return result.values.filter((s): s is PiSession => s !== null);
+}
+
+// ---------------------------------------------------------------------------
+// 时区 / 日期工具
+// ---------------------------------------------------------------------------
+
+const TZ_OFFSETS: Record<string, number> = {
+  'Asia/Shanghai': 8,
+  'Asia/Tokyo': 9,
+  'America/New_York': -5,
+  'America/Los_Angeles': -8,
+  'Europe/London': 0,
+  'UTC': 0,
+};
+
+function getTzOffsetHours(tz: string): number {
+  return TZ_OFFSETS[tz] ?? 8;
+}
+
+function toLocalISO(ts: string, tz: string): Date {
+  const d = new Date(ts);
+  return new Date(d.getTime() + getTzOffsetHours(tz) * 3600_000);
+}
+
+function getDateKey(ts: string, tz: string): string {
+  return toLocalISO(ts, tz).toISOString().slice(0, 10);
+}
+
+function getHourKey(ts: string, tz: string): string {
+  const local = toLocalISO(ts, tz);
+  return local.toISOString().slice(0, 13).replace('T', ' ') + ':00';
+}
+
+/** 从 cwd 提取项目名（兼容 Windows 反斜杠和 Unix 斜杠路径）。 */
+function extractProjectName(cwd: string): string {
+  if (!cwd) return 'unknown';
+  const parts = cwd.replace(/[\\/]+$/, '').split(/[\\/]/);
+  return parts[parts.length - 1] || 'unknown';
+}
+
+// ---------------------------------------------------------------------------
+// 聚合核心
+// ---------------------------------------------------------------------------
+
+function emptyAcc(): TokenAccumulator {
+  return { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, totalTokens: 0, cost: 0 };
+}
+
+function addEvent(acc: TokenAccumulator, ev: PiTokenEvent): void {
+  acc.inputTokens += ev.inputTokens;
+  acc.outputTokens += ev.outputTokens;
+  acc.cacheReadTokens += ev.cacheReadTokens;
+  acc.cacheWriteTokens += ev.cacheWriteTokens;
+  acc.totalTokens += ev.totalTokens;
+  acc.cost += ev.cost;
+}
+
+function mergeAcc(target: TokenAccumulator, source: TokenAccumulator): void {
+  target.inputTokens += source.inputTokens;
+  target.outputTokens += source.outputTokens;
+  target.cacheReadTokens += source.cacheReadTokens;
+  target.cacheWriteTokens += source.cacheWriteTokens;
+  target.totalTokens += source.totalTokens;
+  target.cost += source.cost;
+}
+
+function addToBucket(bucket: AggregateBucket, ev: PiTokenEvent): void {
+  addEvent(bucket.acc, ev);
+  if (!bucket.models.has(ev.model)) bucket.models.set(ev.model, emptyAcc());
+  addEvent(bucket.models.get(ev.model)!, ev);
+}
+
+function accToEntry(date: string, acc: TokenAccumulator, modelAccs: Map<string, TokenAccumulator>): DailyEntry {
+  const modelBreakdowns: ModelBreakdown[] = [...modelAccs.entries()].map(([modelName, m]) => ({
+    modelName,
+    inputTokens: m.inputTokens,
+    outputTokens: m.outputTokens,
+    cacheCreationTokens: m.cacheWriteTokens,
+    cacheReadTokens: m.cacheReadTokens,
+    cost: m.cost,
+  }));
+  return {
+    date,
+    inputTokens: acc.inputTokens,
+    outputTokens: acc.outputTokens,
+    cacheCreationTokens: acc.cacheWriteTokens,
+    cacheReadTokens: acc.cacheReadTokens,
+    totalTokens: acc.totalTokens,
+    totalCost: acc.cost,
+    modelsUsed: [...modelAccs.keys()],
+    modelBreakdowns,
+  };
+}
+
+function groupSessions(
+  sessions: PiSession[],
+  groupBy: 'day' | 'hour' | 'project',
+  tz: string,
+  projectFilter?: string | null,
+): Map<string, AggregateBucket> {
+  const grouped = new Map<string, AggregateBucket>();
+
+  for (const session of sessions) {
+    const projectName = extractProjectName(session.cwd);
+    if (projectFilter && projectName !== projectFilter) continue;
+
+    for (const ev of session.tokenEvents) {
+      let key: string;
+      if (groupBy === 'hour') {
+        key = getHourKey(ev.timestamp, tz);
+      } else if (groupBy === 'project') {
+        key = projectName;
+      } else {
+        key = getDateKey(ev.timestamp, tz);
+      }
+      if (!grouped.has(key)) grouped.set(key, { acc: emptyAcc(), models: new Map() });
+      addToBucket(grouped.get(key)!, ev);
+    }
+  }
+
+  return grouped;
+}
+
+// ---------------------------------------------------------------------------
+// 公开 API
+// ---------------------------------------------------------------------------
+
+export function getDailyResponse(options?: { timezone?: string }): DailyResponse {
+  const tz = options?.timezone || DEFAULT_TZ;
+  const sessions = loadSessions();
+  const grouped = groupSessions(sessions, 'day', tz);
+
+  const daily: DailyEntry[] = [];
+  const totalsAcc = emptyAcc();
+  const totalModels = new Map<string, TokenAccumulator>();
+
+  for (const [date, { acc, models }] of grouped) {
+    daily.push(accToEntry(date, acc, models));
+    mergeAcc(totalsAcc, acc);
+    for (const [model, m] of models) {
+      if (!totalModels.has(model)) totalModels.set(model, emptyAcc());
+      mergeAcc(totalModels.get(model)!, m);
+    }
+  }
+
+  daily.sort((a, b) => a.date.localeCompare(b.date));
+
+  return {
+    daily,
+    totals: {
+      inputTokens: totalsAcc.inputTokens,
+      outputTokens: totalsAcc.outputTokens,
+      cacheCreationTokens: totalsAcc.cacheWriteTokens,
+      cacheReadTokens: totalsAcc.cacheReadTokens,
+      totalTokens: totalsAcc.totalTokens,
+      totalCost: totalsAcc.cost,
+    },
+  };
+}
+
+export function getProjectsResponse(options?: { timezone?: string }): ProjectsResponse {
+  const tz = options?.timezone || DEFAULT_TZ;
+  const sessions = loadSessions();
+
+  // 按项目 → 日期二级分组
+  const projectDaily = new Map<string, Map<string, AggregateBucket>>();
+
+  for (const session of sessions) {
+    const projectName = extractProjectName(session.cwd);
+    if (!projectDaily.has(projectName)) projectDaily.set(projectName, new Map());
+    const dailyMap = projectDaily.get(projectName)!;
+
+    for (const ev of session.tokenEvents) {
+      const dayKey = getDateKey(ev.timestamp, tz);
+      if (!dailyMap.has(dayKey)) dailyMap.set(dayKey, { acc: emptyAcc(), models: new Map() });
+      addToBucket(dailyMap.get(dayKey)!, ev);
+    }
+  }
+
+  const projects: Record<string, DailyEntry[]> = {};
+  for (const [projectName, dailyMap] of projectDaily) {
+    projects[projectName] = [...dailyMap.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, { acc, models }]) => accToEntry(date, acc, models));
+  }
+
+  return { projects };
+}
+
+export function getBlocksResponse(options?: { project?: string | null; timezone?: string }): BlocksResponse {
+  const tz = options?.timezone || DEFAULT_TZ;
+  const sessions = loadSessions();
+  const grouped = groupSessions(sessions, 'hour', tz, options?.project);
+
+  const blocks: BlockEntry[] = [...grouped.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([hourKey, { acc, models }], idx) => {
+      const [datePart, timePart] = hourKey.split(' ');
+      const hour = timePart.split(':')[0];
+      return {
+        id: `pi-hour-${idx}`,
+        startTime: `${datePart}T${hour}:00:00`,
+        endTime: `${datePart}T${hour}:59:59`,
+        actualEndTime: null,
+        isActive: false,
+        isGap: false,
+        entries: acc.totalTokens > 0 ? 1 : 0,
+        tokenCounts: {
+          inputTokens: acc.inputTokens,
+          outputTokens: acc.outputTokens,
+          cacheCreationInputTokens: acc.cacheWriteTokens,
+          cacheReadInputTokens: acc.cacheReadTokens,
+        },
+        totalTokens: acc.totalTokens,
+        costUSD: acc.cost,
+        models: [...models.keys()],
+      };
+    });
+
+  return { blocks };
+}

--- a/src/server/routes/analytics.ts
+++ b/src/server/routes/analytics.ts
@@ -14,7 +14,7 @@ export async function getAnalytics(req: Request, res: Response): Promise<void> {
   const agent = req.query.agent as string || 'claude';
   const project = req.query.project as string || undefined;
 
-  if (agent === 'codex' || agent === 'opencode') {
+  if (agent === 'codex' || agent === 'opencode' || agent === 'pi') {
     res.json(EMPTY_ANALYTICS);
     return;
   }

--- a/src/server/routes/analytics.ts
+++ b/src/server/routes/analytics.ts
@@ -13,6 +13,7 @@ const EMPTY_ANALYTICS = {
 export async function getAnalytics(req: Request, res: Response): Promise<void> {
   const agent = req.query.agent as string || 'claude';
   const project = req.query.project as string || undefined;
+  const force = req.query.refresh === '1' || req.query.refresh === 'true';
 
   if (agent === 'codex' || agent === 'opencode' || agent === 'pi') {
     res.json(EMPTY_ANALYTICS);
@@ -21,18 +22,22 @@ export async function getAnalytics(req: Request, res: Response): Promise<void> {
 
   try {
     const cacheKey = `analytics:${agent}:${project || 'all'}`;
-    const cached = cache.get(cacheKey);
-    if (cached) {
-      res.json(cached);
-      return;
+    if (!force) {
+      const cached = cache.get(cacheKey);
+      if (cached) {
+        res.json(cached);
+        return;
+      }
+
+      const stale = cache.getStale(cacheKey);
+      if (stale) {
+        refreshAnalyticsCache(agent, project, cacheKey);
+        res.json(stale);
+        return;
+      }
     }
 
-    const toolCalls = agent === 'openclaw'
-      ? extractOpenClawToolCalls(project || null)
-      : extractClaudeToolCalls(project || null);
-
-    const data = computeAnalytics(toolCalls);
-    const validated = validateAnalytics(data);
+    const validated = fetchAnalyticsData(agent, project);
     cache.set(cacheKey, validated);
     res.json(validated);
   } catch (error) {
@@ -43,4 +48,17 @@ export async function getAnalytics(req: Request, res: Response): Promise<void> {
       hint: message,
     });
   }
+}
+
+function fetchAnalyticsData(agent: string, project?: string) {
+  const toolCalls = agent === 'openclaw'
+    ? extractOpenClawToolCalls(project || null)
+    : extractClaudeToolCalls(project || null);
+  return validateAnalytics(computeAnalytics(toolCalls));
+}
+
+function refreshAnalyticsCache(agent: string, project: string | undefined, cacheKey: string): void {
+  Promise.resolve()
+    .then(() => cache.set(cacheKey, fetchAnalyticsData(agent, project)))
+    .catch(err => console.error('Background refresh failed (analytics):', err));
 }

--- a/src/server/routes/api.ts
+++ b/src/server/routes/api.ts
@@ -8,6 +8,7 @@ import { getAnalytics } from './analytics.js';
 import { detectAvailableAgents } from '../agentDetection.js';
 import { isOpenClawAccessible } from '../openclawParser.js';
 import { isOpencodeAccessible } from '../opencodeParser.js';
+import { isPiAccessible } from '../piParser.js';
 import { quotaService } from '../quota/index.js';
 import type { QuotaProviderId } from '../quota/index.js';
 
@@ -60,6 +61,7 @@ function getAgents(_req: Request, res: Response): void {
     if (agents.codex) available.push('codex');
     if (isOpenClawAccessible()) available.push('openclaw');
     if (isOpencodeAccessible()) available.push('opencode');
+    if (isPiAccessible()) available.push('pi');
     res.json({ available, default: available[0] || null });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';

--- a/src/server/routes/api.ts
+++ b/src/server/routes/api.ts
@@ -6,9 +6,6 @@ import { getProjects } from './projects.js';
 import { getBlocks } from './blocks.js';
 import { getAnalytics } from './analytics.js';
 import { detectAvailableAgents } from '../agentDetection.js';
-import { isOpenClawAccessible } from '../openclawParser.js';
-import { isOpencodeAccessible } from '../opencodeParser.js';
-import { isPiAccessible } from '../piParser.js';
 import { quotaService } from '../quota/index.js';
 import type { QuotaProviderId } from '../quota/index.js';
 
@@ -59,9 +56,9 @@ function getAgents(_req: Request, res: Response): void {
     const available: string[] = [];
     if (agents.claude) available.push('claude');
     if (agents.codex) available.push('codex');
-    if (isOpenClawAccessible()) available.push('openclaw');
-    if (isOpencodeAccessible()) available.push('opencode');
-    if (isPiAccessible()) available.push('pi');
+    if (agents.openclaw) available.push('openclaw');
+    if (agents.opencode) available.push('opencode');
+    if (agents.pi) available.push('pi');
     res.json({ available, default: available[0] || null });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';

--- a/src/server/routes/blocks.ts
+++ b/src/server/routes/blocks.ts
@@ -5,6 +5,7 @@ import { getBlocksResponse as getCodexBlocksResponse } from '../codexParser.js';
 import { getBlocksResponse as getOpenClawBlocksResponse } from '../openclawParser.js';
 import { getBlocksResponse as getOpencodeBlocksResponse } from '../opencodeParser.js';
 import { getBlocksResponse as getClaudeBlocksResponse } from '../claudeJsonlParser.js';
+import { getBlocksResponse as getPiBlocksResponse } from '../piParser.js';
 
 export async function getBlocks(req: Request, res: Response): Promise<void> {
   const agent = req.query.agent as string || 'claude';
@@ -49,6 +50,8 @@ function fetchBlocksData(agent: string, project?: string) {
     return validateBlocks(getOpencodeBlocksResponse({ project: project || null }));
   } else if (agent === 'codex') {
     return validateBlocks(getCodexBlocksResponse({ project: project || null }));
+  } else if (agent === 'pi') {
+    return validateBlocks(getPiBlocksResponse({ project: project || null }));
   } else {
     // Claude Code: parse JSONL directly (fast, no CLI)
     return validateBlocks(getClaudeBlocksResponse(project || null));

--- a/src/server/routes/daily.ts
+++ b/src/server/routes/daily.ts
@@ -5,6 +5,7 @@ import { getDailyResponse as getCodexDailyResponse } from '../codexParser.js';
 import { getDailyResponse as getOpenClawDailyResponse } from '../openclawParser.js';
 import { getDailyResponse as getOpencodeDailyResponse } from '../opencodeParser.js';
 import { getDailyResponse as getClaudeDailyResponse } from '../claudeJsonlParser.js';
+import { getDailyResponse as getPiDailyResponse } from '../piParser.js';
 
 export async function getDaily(req: Request, res: Response): Promise<void> {
   const agent = req.query.agent as string || 'claude';
@@ -47,6 +48,8 @@ function fetchDailyData(agent: string) {
     return Promise.resolve(validateDaily(getOpenClawDailyResponse()));
   } else if (agent === 'opencode') {
     return Promise.resolve(validateDaily(getOpencodeDailyResponse()));
+  } else if (agent === 'pi') {
+    return Promise.resolve(validateDaily(getPiDailyResponse()));
   } else {
     // Claude Code: parse JSONL directly (fast, no CLI)
     return Promise.resolve(validateDaily(getClaudeDailyResponse()));

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -5,6 +5,7 @@ import { getProjectsResponse as getCodexProjectsResponse } from '../codexParser.
 import { getProjectsResponse as getOpenClawProjectsResponse } from '../openclawParser.js';
 import { getProjectsResponse as getOpencodeProjectsResponse } from '../opencodeParser.js';
 import { getProjectsResponse as getClaudeProjectsResponse } from '../claudeJsonlParser.js';
+import { getProjectsResponse as getPiProjectsResponse } from '../piParser.js';
 
 export async function getProjects(req: Request, res: Response): Promise<void> {
   const agent = req.query.agent as string || 'claude';
@@ -47,6 +48,8 @@ function fetchProjectsData(agent: string) {
     return validateProjects(getOpenClawProjectsResponse());
   } else if (agent === 'opencode') {
     return validateProjects(getOpencodeProjectsResponse());
+  } else if (agent === 'pi') {
+    return validateProjects(getPiProjectsResponse());
   } else {
     // Claude Code: parse JSONL directly (fast, no CLI)
     return validateProjects(getClaudeProjectsResponse());


### PR DESCRIPTION
## Summary

Add Pi Agent (`~/.pi/agent/sessions/`) as a supported usage data source, plus auto-refresh mechanism for dashboard data.

## Changes

### Pi Agent 支持
- New `piParser.ts`: parses Pi JSONL session files, extracts `usage` from assistant messages (input/output/cacheRead/cacheWrite/totalTokens/cost), aggregates by day/project/hour with incremental file index caching
- `agentDetection.ts`: add Pi detection (`~/.pi/agent/sessions` directory)
- Routes (`daily`/`projects`/`blocks`/`analytics`/`api`): dispatch `agent=pi`
- `Dashboard.tsx`: add Pi agent switcher button (violet theme, no analytics section)
- Fix: `index.ts` now calls `main()` when run directly (dev mode was broken — server never started under `tsx watch`)

### 自动刷新机制
- `useCcusageData`: 新增 `intervalMs` 参数（默认 60 秒），定时轮询所有数据接口；新增 `lastUpdated` 时间戳
- `Dashboard.tsx`: 头部显示"更新于 HH:mm:ss"及手动刷新按钮，加载中显示旋转动画；骨架屏与错误视图同步支持刷新

### 其他修复
- dev 模式端口被占用时直接报错退出，不再静默回退导致页面永久加载
- dev 模式不再自动打开浏览器，避免 concurrently 管道死锁

## Testing

- `npm run typecheck` ✅
- `npm test` ✅ (144 passed, 1 pre-existing unrelated failure)
- Manual: `/api/agents` returns `["claude","codex","pi"]` on a machine with Pi installed
