### PR TITLE
Keep daemon responsive during Codex usage scans

### DIFF
--- a/src/__tests__/server/codexResponseService.test.ts
+++ b/src/__tests__/server/codexResponseService.test.ts
@@ -1,0 +1,97 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getCodexDailyResponse, resolveCodexWorkerPath } from '../../server/codexResponseService.js';
+import { cache } from '../../server/cache.js';
+import { clearUsageFileIndexMemory } from '../../server/usageFileIndex.js';
+
+const tempDirs: string[] = [];
+const originalCodexHome = process.env.CODEX_HOME;
+const originalSettingsFile = process.env.TOKENDASH_SETTINGS_FILE;
+const originalIndexDir = process.env.TOKENDASH_USAGE_INDEX_DIR;
+const originalDisableWorker = process.env.TOKENDASH_DISABLE_CODEX_WORKER;
+
+function tokenCount(timestamp: string, totalTokens: number): unknown {
+  return {
+    timestamp,
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info: {
+        total_token_usage: {
+          input_tokens: totalTokens - 10,
+          cached_input_tokens: 0,
+          output_tokens: 10,
+          reasoning_output_tokens: 0,
+          total_tokens: totalTokens,
+        },
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  const root = mkdtempSync(join(tmpdir(), 'tokendash-codex-worker-'));
+  const settingsDir = mkdtempSync(join(tmpdir(), 'tokendash-codex-worker-settings-'));
+  const indexDir = mkdtempSync(join(tmpdir(), 'tokendash-codex-worker-index-'));
+  tempDirs.push(root, settingsDir, indexDir);
+  process.env.CODEX_HOME = root;
+  process.env.TOKENDASH_SETTINGS_FILE = join(settingsDir, 'settings.json');
+  process.env.TOKENDASH_USAGE_INDEX_DIR = indexDir;
+  delete process.env.TOKENDASH_DISABLE_CODEX_WORKER;
+
+  const sessionDir = join(root, 'sessions', '2026', '09', '02');
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(join(sessionDir, 'rollout-worker.jsonl'), [
+    {
+      type: 'session_meta',
+      payload: {
+        id: 'worker-session',
+        cwd: '/tmp/project-a',
+        timestamp: '2026-09-02T00:00:00.000Z',
+      },
+    },
+    { type: 'turn_context', payload: { model: 'gpt-5.5' } },
+    tokenCount('2026-09-02T00:00:01.000Z', 100),
+    tokenCount('2026-09-02T00:00:02.000Z', 175),
+  ].map(line => JSON.stringify(line)).join('\n'));
+});
+
+afterEach(() => {
+  cache.clear();
+  clearUsageFileIndexMemory();
+  if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+  else process.env.CODEX_HOME = originalCodexHome;
+  if (originalSettingsFile === undefined) delete process.env.TOKENDASH_SETTINGS_FILE;
+  else process.env.TOKENDASH_SETTINGS_FILE = originalSettingsFile;
+  if (originalIndexDir === undefined) delete process.env.TOKENDASH_USAGE_INDEX_DIR;
+  else process.env.TOKENDASH_USAGE_INDEX_DIR = originalIndexDir;
+  if (originalDisableWorker === undefined) delete process.env.TOKENDASH_DISABLE_CODEX_WORKER;
+  else process.env.TOKENDASH_DISABLE_CODEX_WORKER = originalDisableWorker;
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('codex response worker', () => {
+  it('computes Codex usage through the non-blocking response service', async () => {
+    const daily = await getCodexDailyResponse({ timezone: 'UTC' });
+
+    expect(daily.daily).toHaveLength(1);
+    expect(daily.daily[0]).toMatchObject({
+      date: '2026-09-02',
+      inputTokens: 165,
+      outputTokens: 10,
+      totalTokens: 175,
+    });
+  });
+
+  it('resolves the sidecar worker next to the compiled bundled daemon', () => {
+    const worker = resolveCodexWorkerPath('file:///tmp/tokendash/dist/daemon.cjs');
+
+    expect(dirname(worker)).toBe('/tmp/tokendash/dist/server');
+    expect(worker.endsWith('codexResponseWorker.js')).toBe(true);
+  });
+});

--- a/src/server/codexResponseService.ts
+++ b/src/server/codexResponseService.ts
@@ -1,0 +1,216 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { Worker } from 'node:worker_threads';
+import type { DailyResponse, ProjectsResponse, BlocksResponse } from '../shared/types.js';
+import { getBlocksResponse, getCodexResponses, getDailyResponse, getProjectsResponse, type AggregateOptions } from './codexParser.js';
+
+interface CodexResponseBundle {
+  daily: DailyResponse;
+  projects: ProjectsResponse;
+  blocks: BlocksResponse;
+}
+
+type CodexResponseKind = 'bundle' | 'daily' | 'projects' | 'blocks';
+
+type CodexResponseByKind<K extends CodexResponseKind> =
+  K extends 'bundle' ? CodexResponseBundle :
+  K extends 'daily' ? DailyResponse :
+  K extends 'projects' ? ProjectsResponse :
+  BlocksResponse;
+
+interface SerializedAggregateOptions {
+  groupBy?: AggregateOptions['groupBy'];
+  project?: string | null;
+  since?: string | null;
+  until?: string | null;
+  timezone?: string;
+}
+
+interface WorkerSuccess<K extends CodexResponseKind> {
+  id: number;
+  ok: true;
+  data: CodexResponseByKind<K>;
+}
+
+interface WorkerFailure {
+  id: number;
+  ok: false;
+  error: string;
+  stack?: string;
+}
+
+const DEFAULT_WORKER_TIMEOUT_MS = 120_000;
+const RESULT_TTL_MS = 30_000;
+let nextRequestId = 1;
+const inFlight = new Map<string, Promise<unknown>>();
+const resultCache = new Map<string, { data: unknown; expiresAt: number }>();
+
+function serializeOptions(options?: Partial<AggregateOptions>): SerializedAggregateOptions | undefined {
+  if (!options) return undefined;
+  return {
+    groupBy: options.groupBy,
+    project: options.project,
+    since: options.since ? options.since.toISOString() : options.since,
+    until: options.until ? options.until.toISOString() : options.until,
+    timezone: options.timezone,
+  };
+}
+
+function requestKey(kind: CodexResponseKind, options?: Partial<AggregateOptions>): string {
+  return `${kind}:${JSON.stringify(serializeOptions(options) ?? {})}`;
+}
+
+function workerTimeoutMs(): number {
+  const raw = Number.parseInt(process.env.TOKENDASH_CODEX_WORKER_TIMEOUT_MS || '', 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_WORKER_TIMEOUT_MS;
+}
+
+export function resolveCodexWorkerPath(moduleUrl = import.meta.url): string {
+  const currentPath = fileURLToPath(moduleUrl);
+  const currentDir = dirname(currentPath);
+
+  // Bundled daemon/electron-server entries live at dist/*.cjs while tsc emits
+  // worker modules to dist/server/*.js. Keep the worker outside the bundle so
+  // heavy Codex parsing cannot block the HTTP server's main event loop.
+  if (currentPath.endsWith('.cjs')) {
+    return join(currentDir, 'server', 'codexResponseWorker.js');
+  }
+
+  const ext = currentPath.endsWith('.ts') ? '.ts' : '.js';
+  const sameDir = join(currentDir, `codexResponseWorker${ext}`);
+  if (existsSync(sameDir)) return sameDir;
+
+  const distServer = join(currentDir, 'server', 'codexResponseWorker.js');
+  if (existsSync(distServer)) return distServer;
+
+  return sameDir;
+}
+
+function workerExecArgv(workerPath: string): string[] {
+  if (!workerPath.endsWith('.ts')) return process.execArgv;
+  const alreadyLoadsTsx = process.execArgv.some(arg => arg.includes('tsx'));
+  if (alreadyLoadsTsx) return process.execArgv;
+  return [...process.execArgv, '--import', 'tsx'];
+}
+
+function runSync<K extends CodexResponseKind>(kind: K, options?: Partial<AggregateOptions>): CodexResponseByKind<K> {
+  switch (kind) {
+    case 'bundle':
+      return getCodexResponses(options) as CodexResponseByKind<K>;
+    case 'daily':
+      return getDailyResponse(options) as CodexResponseByKind<K>;
+    case 'projects':
+      return getProjectsResponse(options) as CodexResponseByKind<K>;
+    case 'blocks':
+      return getBlocksResponse(options) as CodexResponseByKind<K>;
+  }
+}
+
+function runInWorker<K extends CodexResponseKind>(kind: K, options?: Partial<AggregateOptions>): Promise<CodexResponseByKind<K>> {
+  const workerPath = resolveCodexWorkerPath();
+  if (workerPath.endsWith('.ts')) {
+    return Promise.resolve(runSync(kind, options));
+  }
+  const id = nextRequestId++;
+
+  return new Promise<CodexResponseByKind<K>>((resolve, reject) => {
+    const worker = new Worker(pathToFileURL(workerPath), {
+      execArgv: workerExecArgv(workerPath),
+      env: process.env,
+    });
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      void worker.terminate();
+      reject(new Error(`Codex usage parsing timed out after ${workerTimeoutMs()}ms`));
+    }, workerTimeoutMs());
+
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      fn();
+    };
+
+    worker.once('message', (message: WorkerSuccess<K> | WorkerFailure) => {
+      finish(() => {
+        void worker.terminate();
+        if (message.ok) {
+          resolve(message.data);
+        } else {
+          const error = new Error(message.error);
+          if (message.stack) error.stack = message.stack;
+          reject(error);
+        }
+      });
+    });
+
+    worker.once('error', error => {
+      finish(() => {
+        void worker.terminate();
+        reject(error);
+      });
+    });
+
+    worker.once('exit', code => {
+      if (code === 0 || settled) return;
+      finish(() => reject(new Error(`Codex usage worker exited with code ${code}`)));
+    });
+
+    worker.postMessage({ id, kind, options: serializeOptions(options) });
+  });
+}
+
+export async function getCodexResponse<K extends CodexResponseKind>(
+  kind: K,
+  options?: Partial<AggregateOptions>,
+): Promise<CodexResponseByKind<K>> {
+  if (process.env.TOKENDASH_DISABLE_CODEX_WORKER === '1') {
+    return runSync(kind, options);
+  }
+
+  const key = requestKey(kind, options);
+  const cached = resultCache.get(key) as { data: CodexResponseByKind<K>; expiresAt: number } | undefined;
+  if (cached && Date.now() <= cached.expiresAt) return cached.data;
+
+  const existing = inFlight.get(key) as Promise<CodexResponseByKind<K>> | undefined;
+  if (existing) return existing;
+
+  const promise = runInWorker(kind, options)
+    .then(data => {
+      resultCache.set(key, { data, expiresAt: Date.now() + RESULT_TTL_MS });
+      return data;
+    })
+    .finally(() => {
+      inFlight.delete(key);
+    });
+  inFlight.set(key, promise);
+  return promise;
+}
+
+function usesDefaultBundleOptions(options?: Partial<AggregateOptions>): boolean {
+  return !options || (
+    !options.project
+    && !options.since
+    && !options.until
+    && !options.groupBy
+    && (!options.timezone || options.timezone === 'Asia/Shanghai')
+  );
+}
+
+export async function getCodexDailyResponse(options?: Partial<AggregateOptions>): Promise<DailyResponse> {
+  if (usesDefaultBundleOptions(options)) return (await getCodexResponse('bundle')).daily;
+  return getCodexResponse('daily', options);
+}
+
+export async function getCodexProjectsResponse(options?: Partial<AggregateOptions>): Promise<ProjectsResponse> {
+  if (usesDefaultBundleOptions(options)) return (await getCodexResponse('bundle')).projects;
+  return getCodexResponse('projects', options);
+}
+
+export async function getCodexBlocksResponse(options?: Partial<AggregateOptions>): Promise<BlocksResponse> {
+  if (usesDefaultBundleOptions(options)) return (await getCodexResponse('bundle')).blocks;
+  return getCodexResponse('blocks', options);
+}

--- a/src/server/codexResponseWorker.ts
+++ b/src/server/codexResponseWorker.ts
@@ -1,0 +1,59 @@
+import { parentPort } from 'node:worker_threads';
+import type { AggregateOptions } from './codexParser.js';
+
+type CodexParserModule = typeof import('./codexParser.js');
+
+interface SerializedAggregateOptions {
+  groupBy?: AggregateOptions['groupBy'];
+  project?: string | null;
+  since?: string | null;
+  until?: string | null;
+  timezone?: string;
+}
+
+type WorkerRequest =
+  | { id: number; kind: 'bundle'; options?: SerializedAggregateOptions }
+  | { id: number; kind: 'daily'; options?: SerializedAggregateOptions }
+  | { id: number; kind: 'projects'; options?: SerializedAggregateOptions }
+  | { id: number; kind: 'blocks'; options?: SerializedAggregateOptions };
+
+function deserializeOptions(options?: SerializedAggregateOptions): Partial<AggregateOptions> | undefined {
+  if (!options) return undefined;
+  return {
+    groupBy: options.groupBy,
+    project: options.project,
+    since: options.since == null ? options.since : new Date(options.since),
+    until: options.until == null ? options.until : new Date(options.until),
+    timezone: options.timezone,
+  };
+}
+
+async function loadCodexParser(): Promise<CodexParserModule> {
+  const ext = import.meta.url.endsWith('.ts') ? 'ts' : 'js';
+  return import(`./codexParser.${ext}`) as Promise<CodexParserModule>;
+}
+
+async function run(request: WorkerRequest): Promise<unknown> {
+  const parser = await loadCodexParser();
+  const options = deserializeOptions(request.options);
+  switch (request.kind) {
+    case 'daily':
+      return parser.getDailyResponse(options);
+    case 'projects':
+      return parser.getProjectsResponse(options);
+    case 'blocks':
+      return parser.getBlocksResponse(options);
+    case 'bundle':
+      return parser.getCodexResponses(options);
+  }
+}
+
+parentPort?.on('message', (request: WorkerRequest) => {
+  void run(request)
+    .then(data => parentPort?.postMessage({ id: request.id, ok: true, data }))
+    .catch(error => {
+      const message = error instanceof Error ? error.message : String(error);
+      const stack = error instanceof Error ? error.stack : undefined;
+      parentPort?.postMessage({ id: request.id, ok: false, error: message, stack });
+    });
+});

--- a/src/server/routes/blocks.ts
+++ b/src/server/routes/blocks.ts
@@ -1,7 +1,7 @@
 import { type Request, type Response } from 'express';
 import { cache } from '../cache.js';
 import { validateBlocks } from '../../shared/schemas.js';
-import { getBlocksResponse as getCodexBlocksResponse } from '../codexParser.js';
+import { getCodexBlocksResponse } from '../codexResponseService.js';
 import { getBlocksResponse as getOpenClawBlocksResponse } from '../openclawParser.js';
 import { getBlocksResponse as getOpencodeBlocksResponse } from '../opencodeParser.js';
 import { getBlocksResponse as getClaudeBlocksResponse } from '../claudeJsonlParser.js';
@@ -30,7 +30,7 @@ export async function getBlocks(req: Request, res: Response): Promise<void> {
       }
     }
 
-    const data = fetchBlocksData(agent, project);
+    const data = await fetchBlocksData(agent, project);
     cache.set(cacheKey, data);
     res.json(data);
   } catch (error) {
@@ -43,13 +43,13 @@ export async function getBlocks(req: Request, res: Response): Promise<void> {
   }
 }
 
-function fetchBlocksData(agent: string, project?: string) {
+async function fetchBlocksData(agent: string, project?: string) {
   if (agent === 'openclaw') {
     return validateBlocks(getOpenClawBlocksResponse({ project: project || null }));
   } else if (agent === 'opencode') {
     return validateBlocks(getOpencodeBlocksResponse({ project: project || null }));
   } else if (agent === 'codex') {
-    return validateBlocks(getCodexBlocksResponse({ project: project || null }));
+    return validateBlocks(await getCodexBlocksResponse({ project: project || null }));
   } else if (agent === 'pi') {
     return validateBlocks(getPiBlocksResponse({ project: project || null }));
   } else {
@@ -60,6 +60,6 @@ function fetchBlocksData(agent: string, project?: string) {
 
 function refreshBlocksCache(agent: string, project: string | undefined, cacheKey: string): void {
   Promise.resolve()
-    .then(() => { const data = fetchBlocksData(agent, project); cache.set(cacheKey, data); })
+    .then(async () => { const data = await fetchBlocksData(agent, project); cache.set(cacheKey, data); })
     .catch(err => console.error('Background refresh failed (blocks):', err));
 }

--- a/src/server/routes/daily.ts
+++ b/src/server/routes/daily.ts
@@ -1,7 +1,7 @@
 import { type Request, type Response } from 'express';
 import { cache } from '../cache.js';
 import { validateDaily } from '../../shared/schemas.js';
-import { getDailyResponse as getCodexDailyResponse } from '../codexParser.js';
+import { getCodexDailyResponse } from '../codexResponseService.js';
 import { getDailyResponse as getOpenClawDailyResponse } from '../openclawParser.js';
 import { getDailyResponse as getOpencodeDailyResponse } from '../opencodeParser.js';
 import { getDailyResponse as getClaudeDailyResponse } from '../claudeJsonlParser.js';
@@ -41,23 +41,23 @@ export async function getDaily(req: Request, res: Response): Promise<void> {
   }
 }
 
-function fetchDailyData(agent: string) {
+async function fetchDailyData(agent: string) {
   if (agent === 'codex') {
-    return Promise.resolve(getCodexDailyResponse());
+    return getCodexDailyResponse();
   } else if (agent === 'openclaw') {
-    return Promise.resolve(validateDaily(getOpenClawDailyResponse()));
+    return validateDaily(getOpenClawDailyResponse());
   } else if (agent === 'opencode') {
-    return Promise.resolve(validateDaily(getOpencodeDailyResponse()));
+    return validateDaily(getOpencodeDailyResponse());
   } else if (agent === 'pi') {
-    return Promise.resolve(validateDaily(getPiDailyResponse()));
+    return validateDaily(getPiDailyResponse());
   } else {
     // Claude Code: parse JSONL directly (fast, no CLI)
-    return Promise.resolve(validateDaily(getClaudeDailyResponse()));
+    return validateDaily(getClaudeDailyResponse());
   }
 }
 
 function refreshDailyCache(agent: string, cacheKey: string): void {
-  fetchDailyData(agent)
+  void fetchDailyData(agent)
     .then(data => cache.set(cacheKey, data))
     .catch(err => console.error('Background refresh failed (daily):', err));
 }

--- a/src/server/routes/monthly.ts
+++ b/src/server/routes/monthly.ts
@@ -2,7 +2,7 @@ import { type Request, type Response } from 'express';
 import { cache } from '../cache.js';
 import { validateDaily } from '../../shared/schemas.js';
 import { getDailyResponse as getClaudeDailyResponse } from '../claudeJsonlParser.js';
-import { getDailyResponse as getCodexDailyResponse } from '../codexParser.js';
+import { getCodexDailyResponse } from '../codexResponseService.js';
 import { getDailyResponse as getOpenClawDailyResponse } from '../openclawParser.js';
 
 export async function getMonthly(req: Request, res: Response): Promise<void> {
@@ -24,7 +24,7 @@ export async function getMonthly(req: Request, res: Response): Promise<void> {
     // Monthly is same as daily for our parser (aggregated by date already)
     let data;
     if (agent === 'codex') {
-      data = validateDaily(getCodexDailyResponse());
+      data = validateDaily(await getCodexDailyResponse());
     } else if (agent === 'openclaw') {
       data = validateDaily(getOpenClawDailyResponse());
     } else {

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -1,7 +1,7 @@
 import { type Request, type Response } from 'express';
 import { cache } from '../cache.js';
 import { validateProjects } from '../../shared/schemas.js';
-import { getProjectsResponse as getCodexProjectsResponse } from '../codexParser.js';
+import { getCodexProjectsResponse } from '../codexResponseService.js';
 import { getProjectsResponse as getOpenClawProjectsResponse } from '../openclawParser.js';
 import { getProjectsResponse as getOpencodeProjectsResponse } from '../opencodeParser.js';
 import { getProjectsResponse as getClaudeProjectsResponse } from '../claudeJsonlParser.js';
@@ -28,7 +28,7 @@ export async function getProjects(req: Request, res: Response): Promise<void> {
       }
     }
 
-    const data = fetchProjectsData(agent);
+    const data = await fetchProjectsData(agent);
     cache.set(cacheKey, data);
     res.json(data);
   } catch (error) {
@@ -41,7 +41,7 @@ export async function getProjects(req: Request, res: Response): Promise<void> {
   }
 }
 
-function fetchProjectsData(agent: string) {
+async function fetchProjectsData(agent: string) {
   if (agent === 'codex') {
     return getCodexProjectsResponse();
   } else if (agent === 'openclaw') {
@@ -58,6 +58,6 @@ function fetchProjectsData(agent: string) {
 
 function refreshProjectsCache(agent: string, cacheKey: string): void {
   Promise.resolve()
-    .then(() => { const data = fetchProjectsData(agent); cache.set(cacheKey, data); })
+    .then(async () => { const data = await fetchProjectsData(agent); cache.set(cacheKey, data); })
     .catch(err => console.error('Background refresh failed (projects):', err));
 }

--- a/src/server/routes/session.ts
+++ b/src/server/routes/session.ts
@@ -2,7 +2,7 @@ import { type Request, type Response } from 'express';
 import { cache } from '../cache.js';
 import { validateDaily } from '../../shared/schemas.js';
 import { getDailyResponse as getClaudeDailyResponse } from '../claudeJsonlParser.js';
-import { getDailyResponse as getCodexDailyResponse } from '../codexParser.js';
+import { getCodexDailyResponse } from '../codexResponseService.js';
 import { getDailyResponse as getOpenClawDailyResponse } from '../openclawParser.js';
 
 export async function getSession(req: Request, res: Response): Promise<void> {
@@ -24,7 +24,7 @@ export async function getSession(req: Request, res: Response): Promise<void> {
     // Session data uses same daily aggregation
     let data;
     if (agent === 'codex') {
-      data = validateDaily(getCodexDailyResponse());
+      data = validateDaily(await getCodexDailyResponse());
     } else if (agent === 'openclaw') {
       data = validateDaily(getOpenClawDailyResponse());
     } else {


### PR DESCRIPTION
## Summary
- move heavy Codex usage response building off the daemon HTTP event loop via a sidecar worker in compiled builds
- coalesce identical in-flight Codex requests and reuse the computed response bundle briefly across daily/projects/blocks refreshes
- route Codex daily/monthly/session/projects/blocks handlers through the non-blocking response service
- add coverage for the response service and bundled worker path resolution

## Root cause
A cold Codex index rebuild or large active transcript scan runs synchronous filesystem traversal/parsing inside the Express event loop. With large local Codex-compatible homes, the daemon can accept TCP connections but cannot respond to even cheap endpoints like /api/app-info, which makes the native app show "Unable to fetch data".

## Verification
- npm test
- npm run typecheck
- npm run build
- git diff --check
- production dist smoke: started server with a cold TOKENDASH_USAGE_INDEX_DIR, launched /api/daily?agent=codex&refresh=1 against real local history, and verified /api/app-info returned in 0.01s while the Codex parse was still running

## Not tested
- Repackaged macOS app install / Sparkle update flow