### PR TITLE
fix: reconcile Claude usage snapshots and preserve analytics content

### DIFF
--- a/src/__tests__/server/claudeUsageLines.test.ts
+++ b/src/__tests__/server/claudeUsageLines.test.ts
@@ -1,0 +1,18 @@
+import { expect, it } from 'vitest';
+import { claudeUsageLines } from '../../server/claudeUsageLines.js';
+
+it('selects growing snapshots, preserves distinct requests and anonymous rows', () => {
+  const rows = [
+    ['s', 'a', 3], ['s', 'a', 2055], ['s', 'a', 3],
+    ['s', 'b', 2055], ['other', 'a', 2055], ['s', '', 1], ['s', '', 1],
+  ].map(([sessionId, id, output_tokens]) => JSON.stringify({
+    type: 'assistant', sessionId, message: { id, usage: { output_tokens } },
+  }));
+  expect([...claudeUsageLines(rows)]).toEqual([1, 3, 4, 5, 6]);
+});
+
+it('identical snapshots count once, different request IDs remain distinct', () => {
+  const row = (requestId: string) => JSON.stringify({type: 'assistant', requestId,
+    message: {id: 'm', usage: {output_tokens: 20}}});
+  expect([...claudeUsageLines([row('a'), row('a'), row('b')])]).toEqual([1, 2]);
+});

--- a/src/__tests__/server/h1DedupRepro.test.ts
+++ b/src/__tests__/server/h1DedupRepro.test.ts
@@ -1,0 +1,52 @@
+// H1 repro: Claude Code writes one JSONL line per content block for the SAME
+// assistant message, each line carrying the same message.id and the same
+// message.usage snapshot. Verify whether the parser double-counts.
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+const FIXTURE_HOME = '/tmp/deep-tokendash-fixture-home';
+const PROJ_DIR = join(FIXTURE_HOME, '.claude', 'projects', '-tmp-fixture-demo');
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, homedir: () => FIXTURE_HOME };
+});
+
+beforeAll(() => {
+  rmSync(FIXTURE_HOME, { recursive: true, force: true });
+  mkdirSync(PROJ_DIR, { recursive: true });
+  const usage = { input_tokens: 1000, output_tokens: 200, cache_creation_input_tokens: 0, cache_read_input_tokens: 5000 };
+  const lines = [
+    { type: 'assistant', timestamp: '2026-09-05T10:00:00.000Z', message: { id: 'msg_fixture_001', model: 'claude-sonnet-4-6', usage, content: [{ type: 'text', text: 'part1' }] } },
+    { type: 'assistant', timestamp: '2026-09-05T10:00:00.000Z', message: { id: 'msg_fixture_001', model: 'claude-sonnet-4-6', usage, content: [{ type: 'tool_use', id: 'toolu_1', name: 'Bash', input: {} }] } },
+    { type: 'assistant', timestamp: '2026-09-05T10:00:00.000Z', message: { id: 'msg_fixture_001', model: 'claude-sonnet-4-6', usage, content: [{ type: 'text', text: 'part3' }] } },
+  ];
+  writeFileSync(join(PROJ_DIR, 'session-fixture.jsonl'), lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+});
+
+describe('H1: one assistant message split into 3 content-block lines (same message.id, same usage)', () => {
+  it('getDailyResponse should count the message once, not 3x', async () => {
+    const { getDailyResponse } = await import('../../server/claudeJsonlParser.js');
+    const res = getDailyResponse();
+    const day = res.daily.find((d) => d.date === '2026-09-05');
+    expect(day, 'daily entry exists').toBeDefined();
+    // eslint-disable-next-line no-console
+    console.log('ACTUAL day totals:', JSON.stringify(day));
+    console.log('ACTUAL grand totals:', JSON.stringify(res.totals));
+    // Correct values (dedup by message.id): input 1000, output 200, cacheRead 5000, total 6200, cost 0.0075
+    expect(day!.inputTokens).toBe(1000);
+    expect(day!.outputTokens).toBe(200);
+    expect(day!.cacheReadTokens).toBe(5000);
+    expect(day!.totalTokens).toBe(6200);
+    expect(day!.totalCost).toBeCloseTo(0.0075, 4);
+  });
+
+  it('getBlocksResponse should count the message once, not 3x', async () => {
+    const { getBlocksResponse } = await import('../../server/claudeJsonlParser.js');
+    const res = getBlocksResponse(null, 'UTC', 'hour');
+    console.log('ACTUAL blocks:', JSON.stringify(res.blocks));
+    const total = res.blocks.reduce((s, b) => s + b.totalTokens, 0);
+    expect(total).toBe(6200);
+  });
+});

--- a/src/__tests__/server/h1DedupRepro.test.ts
+++ b/src/__tests__/server/h1DedupRepro.test.ts
@@ -1,11 +1,12 @@
 // H1 repro: Claude Code writes one JSONL line per content block for the SAME
-// assistant message, each line carrying the same message.id and the same
-// message.usage snapshot. Verify whether the parser double-counts.
-import { describe, it, expect, vi, beforeAll } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+// assistant message, each line carrying the same message.id and possibly growing
+// cumulative usage snapshots. Verify whether the parser double-counts.
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'node:fs';
 import { join } from 'node:path';
 
-const FIXTURE_HOME = '/tmp/deep-tokendash-fixture-home';
+const FIXTURE_HOME = mkdtempSync('/tmp/tokendash-snapshots-');
+afterAll(() => rmSync(FIXTURE_HOME, { recursive: true, force: true }));
 const PROJ_DIR = join(FIXTURE_HOME, '.claude', 'projects', '-tmp-fixture-demo');
 
 vi.mock('node:os', async (importOriginal) => {
@@ -14,39 +15,43 @@ vi.mock('node:os', async (importOriginal) => {
 });
 
 beforeAll(() => {
-  rmSync(FIXTURE_HOME, { recursive: true, force: true });
   mkdirSync(PROJ_DIR, { recursive: true });
   const usage = { input_tokens: 1000, output_tokens: 200, cache_creation_input_tokens: 0, cache_read_input_tokens: 5000 };
   const lines = [
     { type: 'assistant', timestamp: '2026-09-05T10:00:00.000Z', message: { id: 'msg_fixture_001', model: 'claude-sonnet-4-6', usage, content: [{ type: 'text', text: 'part1' }] } },
-    { type: 'assistant', timestamp: '2026-09-05T10:00:00.000Z', message: { id: 'msg_fixture_001', model: 'claude-sonnet-4-6', usage, content: [{ type: 'tool_use', id: 'toolu_1', name: 'Bash', input: {} }] } },
+    { type: 'assistant', timestamp: '2026-09-05T10:00:00.000Z', message: { id: 'msg_fixture_001', model: 'claude-sonnet-4-6', usage: { ...usage, output_tokens: 2055 }, content: [{ type: 'tool_use', id: 'toolu_1', name: 'Bash', input: {} }] } },
     { type: 'assistant', timestamp: '2026-09-05T10:00:00.000Z', message: { id: 'msg_fixture_001', model: 'claude-sonnet-4-6', usage, content: [{ type: 'text', text: 'part3' }] } },
   ];
   writeFileSync(join(PROJ_DIR, 'session-fixture.jsonl'), lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
 });
 
-describe('H1: one assistant message split into 3 content-block lines (same message.id, same usage)', () => {
+describe('H1: one assistant message split into 3 content-block lines (same message.id, growing usage)', () => {
   it('getDailyResponse should count the message once, not 3x', async () => {
     const { getDailyResponse } = await import('../../server/claudeJsonlParser.js');
     const res = getDailyResponse();
     const day = res.daily.find((d) => d.date === '2026-09-05');
     expect(day, 'daily entry exists').toBeDefined();
-    // eslint-disable-next-line no-console
-    console.log('ACTUAL day totals:', JSON.stringify(day));
-    console.log('ACTUAL grand totals:', JSON.stringify(res.totals));
-    // Correct values (dedup by message.id): input 1000, output 200, cacheRead 5000, total 6200, cost 0.0075
+    // Correct values (dedup by message.id): input 1000, output 2055, cacheRead 5000, total 8055, cost 0.035325
     expect(day!.inputTokens).toBe(1000);
-    expect(day!.outputTokens).toBe(200);
+    expect(day!.outputTokens).toBe(2055);
     expect(day!.cacheReadTokens).toBe(5000);
-    expect(day!.totalTokens).toBe(6200);
-    expect(day!.totalCost).toBeCloseTo(0.0075, 4);
+    expect(day!.totalTokens).toBe(8055);
+    expect(day!.totalCost).toBeCloseTo(0.0353, 6);
   });
 
   it('getBlocksResponse should count the message once, not 3x', async () => {
     const { getBlocksResponse } = await import('../../server/claudeJsonlParser.js');
     const res = getBlocksResponse(null, 'UTC', 'hour');
-    console.log('ACTUAL blocks:', JSON.stringify(res.blocks));
     const total = res.blocks.reduce((s, b) => s + b.totalTokens, 0);
-    expect(total).toBe(6200);
+    expect(total).toBe(8055);
   });
+});
+
+it('analytics preserves tool content from later blocks', async () => {
+  const { getSessionDetail } = await import('../../server/sessionAnalyticsParser.js');
+  const detail = getSessionDetail('claude', 'session-fixture');
+  expect(detail).toBeDefined();
+  expect(detail!.events.filter(e => e.type === 'tool_call')).toHaveLength(1);
+  expect(detail!.events.filter(e => e.type === 'assistant_message')).toHaveLength(2);
+  expect(detail!.events.filter(e => e.type === 'llm_call')).toHaveLength(1);
 });

--- a/src/server/claudeJsonlParser.ts
+++ b/src/server/claudeJsonlParser.ts
@@ -1,3 +1,4 @@
+import { claudeUsageLines } from './claudeUsageLines.js';
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
@@ -201,12 +202,10 @@ function parseClaudeUsageFile(file: ClaudeUsageFileRef): ClaudeFileAggregate {
     return summary;
   }
   const projectName = extractProjectName(file.projectDir);
-  // Claude Code writes one JSONL line per content block of the same assistant
-  // message, each carrying the same message.id and the same usage snapshot.
-  // Deduplicate by message.id so multi-block messages are counted once.
-  const seenMessageIds = new Set<string>();
+  const lines = content.split('\n');
+  const usageLines = claudeUsageLines(lines);
 
-  for (const line of content.split('\n')) {
+  for (const [lineIndex, line] of lines.entries()) {
     const trimmed = line.trim();
     if (!trimmed) continue;
 
@@ -215,11 +214,7 @@ function parseClaudeUsageFile(file: ClaudeUsageFileRef): ClaudeFileAggregate {
 
     if (obj.type !== 'assistant' || !obj.message) continue;
     const msg = obj.message as Record<string, unknown>;
-    const messageId = typeof msg.id === 'string' ? msg.id : null;
-    if (messageId !== null) {
-      if (seenMessageIds.has(messageId)) continue;
-      seenMessageIds.add(messageId);
-    }
+    if (!usageLines.has(lineIndex)) continue;
     const usage = (msg.usage as Record<string, number>) || {};
 
     const inputTokens = usage.input_tokens || 0;

--- a/src/server/claudeJsonlParser.ts
+++ b/src/server/claudeJsonlParser.ts
@@ -201,6 +201,10 @@ function parseClaudeUsageFile(file: ClaudeUsageFileRef): ClaudeFileAggregate {
     return summary;
   }
   const projectName = extractProjectName(file.projectDir);
+  // Claude Code writes one JSONL line per content block of the same assistant
+  // message, each carrying the same message.id and the same usage snapshot.
+  // Deduplicate by message.id so multi-block messages are counted once.
+  const seenMessageIds = new Set<string>();
 
   for (const line of content.split('\n')) {
     const trimmed = line.trim();
@@ -211,6 +215,11 @@ function parseClaudeUsageFile(file: ClaudeUsageFileRef): ClaudeFileAggregate {
 
     if (obj.type !== 'assistant' || !obj.message) continue;
     const msg = obj.message as Record<string, unknown>;
+    const messageId = typeof msg.id === 'string' ? msg.id : null;
+    if (messageId !== null) {
+      if (seenMessageIds.has(messageId)) continue;
+      seenMessageIds.add(messageId);
+    }
     const usage = (msg.usage as Record<string, number>) || {};
 
     const inputTokens = usage.input_tokens || 0;

--- a/src/server/claudeUsageLines.ts
+++ b/src/server/claudeUsageLines.ts
@@ -1,0 +1,29 @@
+type Row = Record<string, unknown>;
+
+/** Select whole cumulative usage snapshots; never discard content blocks.
+ * Claude output grows within a request. Prefer the greatest output snapshot,
+ * and the later record on ties. Missing IDs stay independent. Conflicting
+ * non-monotonic producer formats are outside this reconciliation contract.
+ */
+export function claudeUsageLines(lines: string[]): Set<number> {
+  const selected = new Map<string, { index: number; output: number }>();
+  const result = new Set<number>();
+  lines.forEach((line, index) => {
+    let row: Row;
+    try { row = JSON.parse(line) as Row; } catch { return; }
+    if (!row || row.type !== 'assistant') return;
+    const msg = row.message as Row | undefined;
+    const usage = msg?.usage as Row | undefined;
+    if (!usage) return;
+    const output = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
+    if (typeof msg?.id !== 'string' || !msg.id) { result.add(index); return; }
+    const key = JSON.stringify([row.sessionId ?? row.session_id ?? '', row.requestId ?? '', msg.id]);
+    const previous = selected.get(key);
+    if (!previous || output >= previous.output) {
+      if (previous) result.delete(previous.index);
+      selected.set(key, { index, output });
+      result.add(index);
+    }
+  });
+  return result;
+}

--- a/src/server/sessionAnalyticsParser.ts
+++ b/src/server/sessionAnalyticsParser.ts
@@ -634,6 +634,10 @@ function claudeSessionsFromFile(filepath: string): MutableClaudeSession[] {
   const fallbackId = basename(filepath, '.jsonl');
   const sessions = new Map<string, MutableClaudeSession>();
   const toolNames = new Map<string, { name: string; isSkill: boolean }>();
+  // Claude Code emits one JSONL line per content block of the same assistant
+  // message, each carrying the same message.id and usage snapshot; count each
+  // message once.
+  const seenMessageIds = new Set<string>();
 
   for (const line of raw.split('\n')) {
     if (!line.trim()) continue;
@@ -700,6 +704,11 @@ function claudeSessionsFromFile(filepath: string): MutableClaudeSession[] {
     if (entry.type !== 'assistant') continue;
     const message = entry.message as Record<string, unknown> | undefined;
     if (!message) continue;
+    const messageId = typeof message.id === 'string' ? message.id : null;
+    if (messageId !== null) {
+      if (seenMessageIds.has(messageId)) continue;
+      seenMessageIds.add(messageId);
+    }
     const model = typeof message.model === 'string' ? message.model : 'unknown';
     const usage = (message.usage ?? {}) as Record<string, unknown>;
     const inputTokens = typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;

--- a/src/server/sessionAnalyticsParser.ts
+++ b/src/server/sessionAnalyticsParser.ts
@@ -1,3 +1,4 @@
+import { claudeUsageLines } from './claudeUsageLines.js';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { homedir } from 'node:os';
@@ -634,12 +635,10 @@ function claudeSessionsFromFile(filepath: string): MutableClaudeSession[] {
   const fallbackId = basename(filepath, '.jsonl');
   const sessions = new Map<string, MutableClaudeSession>();
   const toolNames = new Map<string, { name: string; isSkill: boolean }>();
-  // Claude Code emits one JSONL line per content block of the same assistant
-  // message, each carrying the same message.id and usage snapshot; count each
-  // message once.
-  const seenMessageIds = new Set<string>();
+  const lines = raw.split('\n');
+  const usageLines = claudeUsageLines(lines);
 
-  for (const line of raw.split('\n')) {
+  for (const [lineIndex, line] of lines.entries()) {
     if (!line.trim()) continue;
     let entry: Record<string, unknown>;
     try {
@@ -704,13 +703,8 @@ function claudeSessionsFromFile(filepath: string): MutableClaudeSession[] {
     if (entry.type !== 'assistant') continue;
     const message = entry.message as Record<string, unknown> | undefined;
     if (!message) continue;
-    const messageId = typeof message.id === 'string' ? message.id : null;
-    if (messageId !== null) {
-      if (seenMessageIds.has(messageId)) continue;
-      seenMessageIds.add(messageId);
-    }
     const model = typeof message.model === 'string' ? message.model : 'unknown';
-    const usage = (message.usage ?? {}) as Record<string, unknown>;
+    const usage = (usageLines.has(lineIndex) ? message.usage ?? {} : {}) as Record<string, unknown>;
     const inputTokens = typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;
     const outputTokens = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
     const cacheCreationTokens = typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0;


### PR DESCRIPTION
Claude transcript rows can repeat a message's usage across content blocks, and later rows can carry a larger cumulative output count. First-wins deduplication therefore fixes overcounting but can introduce undercounting.

This revision selects one **whole usage snapshot** per file-scoped session/request/message identity: greatest `output_tokens`, with later records winning ties. Anonymous records remain independent. It does not construct a synthetic usage vector from independent field maxima. The rule assumes cumulative, monotonic output within a Claude request; it is not a general reconciliation rule for arbitrary producers or a claim of billing accuracy.

Daily/block aggregates and session analytics share the usage selector. Analytics no longer skips an entire repeated-message row: later tool calls and assistant text are preserved independently of usage selection.

Validation: full Vitest suite — 194 tests pass — and server/frontend type checks pass. Committed cases cover growing/stale snapshots, identical snapshots, session/request identity, anonymous rows, daily/block totals and retention of later tool/text content. The parser integration regressions fail on the previous PR head and pass after this revision. Temporary fixture homes are unique and cleaned up.
